### PR TITLE
add functionality to the reset button, and add timeline canvas below the scrolled composite chart

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/ChartFilterControlBar.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/ChartFilterControlBar.java
@@ -12,15 +12,13 @@ import org.eclipse.swt.widgets.DateTime;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Listener;
-import org.openjdk.jmc.ui.charts.XYChart;
 
 public class ChartFilterControlBar extends Composite {
 
 	private DateTime fromTime;
 	private DateTime toTime;
-	private XYChart chart;
 	
-	public ChartFilterControlBar(Composite parent) {
+	public ChartFilterControlBar(Composite parent, Listener resetListener) {
 		super(parent, SWT.NO_BACKGROUND);
 
 		RowLayout layout = new RowLayout();
@@ -70,15 +68,6 @@ public class ChartFilterControlBar extends Composite {
 		Button resetBtn = new Button(this, SWT.PUSH);
 		resetBtn.setText("Reset");
 		resetBtn.setLayoutData(new RowData(60, 20));
-		resetBtn.addListener(SWT.Selection,  new Listener() {
-			@Override
-			public void handleEvent(Event event) {
-				//
-			}
-		});
-	}
-
-	public void setChart(XYChart chart) {
-		this.chart = chart;
+		resetBtn.addListener(SWT.Selection, resetListener);
 	}
 }

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/FlavorSelector.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/FlavorSelector.java
@@ -65,7 +65,9 @@ import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Canvas;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Listener;
 import org.eclipse.ui.forms.widgets.Form;
 
 import org.openjdk.jmc.common.IDisplayable;
@@ -301,7 +303,6 @@ public class FlavorSelector implements SelectionStoreListener {
 		sameThreadsButton.addSelectionListener(new SameThreadsSelectionListener());
 
 		// FIXME: Persist state for above checkboxes?
-
 		onShow.ifPresent(on -> {
 			Label rangeLabel = new Label(selectorRow, SWT.NONE);
 			rangeLabel.setLayoutData(GridDataFactory.swtDefaults().create());
@@ -314,6 +315,12 @@ public class FlavorSelector implements SelectionStoreListener {
 			resetButton.setText(Messages.FlavorSelector_BUTTON_TIMERANGE_CLEAR);
 			resetButton.setToolTipText(Messages.FlavorSelector_BUTTON_TIMERANGE_CLEAR_TOOLTIP);
 			resetButton.addListener(SWT.Selection, e -> on.accept(false));
+			resetButton.addListener(SWT.Selection, new Listener() {
+				@Override
+				public void handleEvent(Event event) {
+					on.accept(false);
+				}
+			});
 			resetButton.setLayoutData(GridDataFactory.swtDefaults().create());
 			showButton.addListener(SWT.Selection, e -> on.accept(true));
 		});

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/AWTChartToolkit.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/AWTChartToolkit.java
@@ -290,6 +290,7 @@ public class AWTChartToolkit {
 		ctx.setTransform(oldTransform);
 	}
 
+	// TODO: add offset attribute instead of hardcoding 180
 	public static void drawAxis(
 		Graphics2D ctx, SubdividedQuantityRange range, int axisPos, boolean labelAhead, int labelLimit,
 		boolean vertical) {
@@ -305,7 +306,7 @@ public class AWTChartToolkit {
 			drawUpArrow(ctx, axisPos, Y_AXIS_TOP_SPACE, Math.min(ARROW_SIZE, axisSize - 2));
 			labelSpacing = fm.getHeight() - textAscent;
 		} else {
-			ctx.drawLine(0, axisPos, axisSize - 1, axisPos);
+			ctx.drawLine(0, axisPos, axisSize + 1 + 180, axisPos);
 			labelSpacing = fm.charWidth(' ') * 2;
 		}
 
@@ -354,14 +355,14 @@ public class AWTChartToolkit {
 					} else {
 						label = formatter.format(currentTick);
 					}
-					ctx.drawLine(tickPos, axisPos - TICK_LINE, tickPos, axisPos + TICK_LINE);
+					ctx.drawLine(tickPos + 180, axisPos - TICK_LINE, tickPos + 180, axisPos + TICK_LINE);
 					int textXadjust = fm.stringWidth(label) / 2;
 					// FIXME: Decide if truncated labels should be shown
 //					if ((tickPos + textXadjust) >= axisSize) {
 					if (tickPos >= axisSize) {
 						break;
 					} else if ((tickPos - textXadjust) >= labelLimit) {
-						ctx.drawString(label, tickPos - textXadjust, labelYPos);
+						ctx.drawString(label, tickPos - textXadjust + 180, labelYPos);
 						labelLimit = tickPos + textXadjust + labelSpacing;
 						lastShownTick = currentTick;
 					}

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/TimelineCanvas.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/TimelineCanvas.java
@@ -12,28 +12,57 @@ import org.openjdk.jmc.ui.common.PatternFly.Palette;
 import org.openjdk.jmc.ui.misc.AwtCanvas;
 
 public class TimelineCanvas extends Canvas {
-	private static final int RANGE_INDICATOR_HEIGHT = 10;
+	private static final int RANGE_INDICATOR_HEIGHT = 7;
+	private static final int RANGE_INDICATOR_Y_OFFSET = 30;
+	private final int xOffset;
 	private AwtCanvas awtCanvas;
 	private Graphics2D g2d;
+	private int x1;
+	private int x2;
+	private int axisWidth;
+	private SubdividedQuantityRange xTickRange;
 
-	public TimelineCanvas(Composite parent) {
+	public TimelineCanvas(Composite parent, int xOffset) {
 		super (parent, SWT.NONE);
+		this.xOffset = xOffset;
 		awtCanvas = new AwtCanvas();
-		addPaintListener(new Painter());
+		addPaintListener(new TimelineCanvasPainter());
 	}
 
-	public void renderTimeline(int x1, int x2, int axisWidth) {
-		// TODO
+	public void renderRangeIndicator(int x1, int x2, int axisWidth) {
+		this.x1 = x1;
+		this.x2 = x2;
+		this.axisWidth = axisWidth;
+		this.redraw();
 	}
 
-	class Painter implements PaintListener {
+	public void renderAxis(SubdividedQuantityRange xTickRange) {
+		this.xTickRange = xTickRange;
+		this.redraw();
+	}
+
+	private class TimelineCanvasPainter implements PaintListener {
 
 		@Override
 		public void paintControl(PaintEvent e) {
 			Rectangle rect = getClientArea();
 			g2d = awtCanvas.getGraphics(rect.width, rect.height);
+			// Draw the background
 			g2d.setColor(Palette.PF_BLACK_100.getAWTColor());
 			g2d.fillRect(0, 0, rect.width, rect.height);
+
+			// Draw the horizontal axis
+			if (xTickRange != null) {
+				g2d.setColor(Palette.PF_BLACK.getAWTColor());
+				AWTChartToolkit.drawAxis(g2d, xTickRange, 0, false, 1 - xOffset, false);
+			}
+
+			// Draw the range indicator
+			g2d.setPaint(Palette.PF_ORANGE_400.getAWTColor());
+			g2d.fillRect(x1 + xOffset, RANGE_INDICATOR_Y_OFFSET, x2 - x1, RANGE_INDICATOR_HEIGHT);
+			g2d.setPaint(Palette.PF_BLACK_600.getAWTColor());
+			g2d.drawRect(xOffset, RANGE_INDICATOR_Y_OFFSET, axisWidth, RANGE_INDICATOR_HEIGHT);
+
 			awtCanvas.paint(e, 0, 0);
 		}
 	}

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/XYChart.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/XYChart.java
@@ -77,7 +77,7 @@ public class XYChart {
 	private SubdividedQuantityRange xBucketRange;
 	private SubdividedQuantityRange xTickRange;
 	private int axisWidth;
-	private TimelineCanvas timeline;
+	private TimelineCanvas timelineCanvas;
 
 	public XYChart(IRange<IQuantity> range, IXDataRenderer rendererRoot) {
 		this(range.getStart(), range.getEnd(), rendererRoot);
@@ -87,9 +87,9 @@ public class XYChart {
 		this(range.getStart(), range.getEnd(), rendererRoot, xOffset);
 	}
 
-	public XYChart(IRange<IQuantity> range, IXDataRenderer rendererRoot, int xOffset, TimelineCanvas timeline) {
+	public XYChart(IRange<IQuantity> range, IXDataRenderer rendererRoot, int xOffset, TimelineCanvas timelineCanvas) {
 		this(range.getStart(), range.getEnd(), rendererRoot, xOffset);
-		this.timeline = timeline;
+		this.timelineCanvas = timelineCanvas;
 	}
 	
 	public XYChart(IRange<IQuantity> range, IXDataRenderer rendererRoot, int xOffset, int bucketWidth) {
@@ -161,16 +161,10 @@ public class XYChart {
 		SubdividedQuantityRange fullRangeAxis = new SubdividedQuantityRange(start, end, axisWidth, 25);
 		int x1 = (int) fullRangeAxis.getPixel(currentStart);
 		int x2 = (int) Math.ceil(fullRangeAxis.getPixel(currentEnd));
-		if (timeline != null) {
-			timeline.renderTimeline(x1, x2, axisWidth);
-			context.setColor(Palette.PF_BLUE.getAWTColor());
-			context.drawLine(0, 0, 25, 0);
-			context.setPaint(Palette.PF_ORANGE_400.getAWTColor());
-			context.fillRect(x1, 0, x2 - x1, RANGE_INDICATOR_HEIGHT);
-			context.setPaint(Palette.PF_BLACK_600.getAWTColor());
-			context.drawRect(0, 0, axisWidth - 1, RANGE_INDICATOR_HEIGHT);
+		
+		if (timelineCanvas != null) {
+			timelineCanvas.renderRangeIndicator(x1, x2, axisWidth);
 		} else {
-			// init the timeline canvas in the ChartAndTableUI and have it render the timeline here.
 			context.setPaint(RANGE_INDICATION_COLOR);
 			context.fillRect(x1, rangeIndicatorY, x2 - x1, RANGE_INDICATOR_HEIGHT);
 			context.setPaint(Color.DARK_GRAY);
@@ -183,7 +177,11 @@ public class XYChart {
 		AWTChartToolkit.drawGrid(context, xTickRange, axisHeight, false);
 		// Attempt to make graphs so low they cover the axis show by drawing the full axis first ...
 		context.setPaint(Color.BLACK);
-		AWTChartToolkit.drawAxis(context, xTickRange, axisHeight - 1, false, 1 - xOffset, false);
+		if (timelineCanvas != null) {
+			timelineCanvas.renderAxis(xTickRange);
+		} else {
+			AWTChartToolkit.drawAxis(context, xTickRange, axisHeight - 1, false, 1 - xOffset, false);
+		}
 		// ... then the graph ...
 		rendererResult = rendererRoot.render(context, xBucketRange, axisHeight);
 		AffineTransform oldTransform = context.getTransform();

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartCanvas.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartCanvas.java
@@ -32,15 +32,11 @@
  */
 package org.openjdk.jmc.ui.misc;
 
-import java.awt.Color;
 import java.awt.Graphics2D;
-import java.awt.geom.Dimension2D;
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.util.IPropertyChangeListener;


### PR DESCRIPTION
* adds functionality to reset the chart via the "reset" button in the filter control bar
* adds a timeline canvas view below the chart that is always visible
* cleans up composites in ChartAndPopupTableUI
* removes old wip functionality from ChartAndTableUI