### PR TITLE
fix lane height sizing and remove the cancel button from the table popup

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/ChartDisplayControlBar.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/ChartDisplayControlBar.java
@@ -115,4 +115,10 @@ public class ChartDisplayControlBar extends Composite {
 		Button durationBtn = new Button(this, SWT.TOGGLE);
 		durationBtn.setImage(UIPlugin.getDefault().getImage(UIPlugin.ICON_FA_SCALE_TO_FIT));
 	}
+
+	public void resetZoomScale() {
+//		this.scale.setSelection(scale.getMaximum());
+//		zoomValue = 0;
+//		text.setText(Integer.toString(0));
+	}
 }

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/ScrolledCompositeToolkit.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/ScrolledCompositeToolkit.java
@@ -13,7 +13,7 @@ public class ScrolledCompositeToolkit extends FormToolkit {
 	}
 
 	public ScrolledComposite createScrolledComposite(Composite parent) {
-		return new ScrolledComposite(parent, SWT.V_SCROLL | SWT.BORDER);
+		return new ScrolledComposite(parent, SWT.BORDER | SWT.H_SCROLL | SWT.V_SCROLL);
 	}
 
 }

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ChartAndPopupTableUI.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ChartAndPopupTableUI.java
@@ -113,6 +113,7 @@ abstract class ChartAndPopupTableUI implements IPageUI {
 	private TimelineCanvas timelineCanvas;
 	protected Composite controls;
 	public ChartFilterControlBar ctf;
+	private ChartDisplayControlBar cdcb;
 
 	ChartAndPopupTableUI(IItemFilter pageFilter, StreamModel model, Composite parent, FormToolkit toolkit,
 			IPageContainer pageContainer, IState state, String sectionTitle, IItemFilter tableFilter, Image icon,
@@ -184,7 +185,7 @@ abstract class ChartAndPopupTableUI implements IPageUI {
 		timelineCanvas.setLayoutData(gridData);
 
 		// add the display bar to the right of the chart scrolled composite
-		ChartDisplayControlBar cdcb = new ChartDisplayControlBar(graphContainer);
+		cdcb = new ChartDisplayControlBar(graphContainer);
 
 		allChartSeriesActions = initializeChartConfiguration(state);
 		IState chartState = state.getChild(CHART);
@@ -246,6 +247,7 @@ abstract class ChartAndPopupTableUI implements IPageUI {
 	private void onSetRange(Boolean useRange) {
 		IRange<IQuantity> range = useRange ? timeRange : pageContainer.getRecordingRange();
 		chart.setVisibleRange(range.getStart(), range.getEnd());
+		cdcb.resetZoomScale();
 		buildChart();
 	}
 

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ThreadsPage.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ThreadsPage.java
@@ -180,7 +180,6 @@ public class ThreadsPage extends AbstractDataPage {
 		private static final String TABLE = "table"; //$NON-NLS-1$
 		private Boolean isChartMenuActionsInit;
 		private Boolean isChartModified;
-		private Boolean isToolbarAction = false;
 		private Boolean reloadThreads;
 		private IAction hideThreadAction;
 		private IAction resetChartAction;
@@ -200,8 +199,8 @@ public class ThreadsPage extends AbstractDataPage {
 					.add(ActionToolkit.action(() -> lanes.openEditLanesDialog(mm, false), Messages.ThreadsPage_EDIT_LANES,
 							FlightRecorderUI.getDefault().getMCImageDescriptor(ImageConstants.ICON_LANES_EDIT)));
 			form.getToolBarManager()
-			.add(ActionToolkit.action(() -> openViewThreadDetailsDialog(state), Messages.ThreadsPage_VIEW_THREAD_DETAILS,
-					FlightRecorderUI.getDefault().getMCImageDescriptor(ImageConstants.ICON_TABLE)));
+					.add(ActionToolkit.action(() -> openViewThreadDetailsDialog(state), Messages.ThreadsPage_VIEW_THREAD_DETAILS,
+							FlightRecorderUI.getDefault().getMCImageDescriptor(ImageConstants.ICON_TABLE)));
 			form.getToolBarManager().update(true);
 			chartLegend.getControl().dispose();
 			buildChart();
@@ -218,7 +217,7 @@ public class ThreadsPage extends AbstractDataPage {
 				}
 			});
 			controls.pack();
-			
+
 //			Composite embed = new Composite(controls, SWT.EMBEDDED);
 //			embed.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
 //			Frame frame = SWT_AWT.new_Frame(embed);
@@ -410,9 +409,10 @@ public class ThreadsPage extends AbstractDataPage {
 			return lanes.initializeChartConfiguration(Stream.of(state.getChildren(THREAD_LANE)));
 		}
 
+		private TablePopup tablePopup;
 		public void openViewThreadDetailsDialog(IState state) {
-			TablePopup tablePopup = new TablePopup(state);
-			OnePageWizardDialog.open(tablePopup, 500, 600);
+			tablePopup = new TablePopup(state);
+			OnePageWizardDialog.openAndHideCancelButton(tablePopup, 500, 600);
 		}
 
 		private class TablePopup extends WizardPage {
@@ -428,7 +428,6 @@ public class ThreadsPage extends AbstractDataPage {
 
 			@Override
 			public void createControl(Composite parent) {
-
 				table = buildHistogram(parent, state.getChild(TABLE));
 				MCContextMenuManager mm = MCContextMenuManager.create(table.getManager().getViewer().getControl());
 				ColumnMenusFactory.addDefaultMenus(table.getManager(), mm);

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/TimelineCanvas.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/TimelineCanvas.java
@@ -47,6 +47,7 @@ public class TimelineCanvas extends Canvas {
 		public void paintControl(PaintEvent e) {
 			Rectangle rect = getClientArea();
 			g2d = awtCanvas.getGraphics(rect.width, rect.height);
+
 			// Draw the background
 			g2d.setColor(Palette.PF_BLACK_100.getAWTColor());
 			g2d.fillRect(0, 0, rect.width, rect.height);

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartCanvas.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartCanvas.java
@@ -75,6 +75,7 @@ import org.openjdk.jmc.ui.common.util.Environment.OSType;
 import org.openjdk.jmc.ui.handlers.MCContextMenuManager;
 
 public class ChartCanvas extends Canvas {
+	private static int MIN_LANE_HEIGHT = 50;
 	private int lastMouseX = -1;
 	private int lastMouseY = -1;
 	private List<Rectangle2D> highlightRects;
@@ -217,19 +218,21 @@ public class ChartCanvas extends Canvas {
 
 		@Override
 		public void paintControl(PaintEvent e) {
-			Rectangle rect = getClientArea();
+			Rectangle rect = new Rectangle(0, 0, getParent().getSize().x, getParent().getSize().y);
+			if (getNumItems() == 1 || (MIN_LANE_HEIGHT * getNumItems() < rect.height)) {
+				// it fills the height
+			} else {
+				rect.height = MIN_LANE_HEIGHT * getNumItems();
+			}
+
 			if (awtNeedsRedraw || !awtCanvas.hasImage(rect.width, rect.height)) {
 				Graphics2D g2d = awtCanvas.getGraphics(rect.width, rect.height);
-				if (getNumItems() > 0) {
-					g2d.getFontMetrics().getHeight();
-					rect.height = 3 * g2d.getFontMetrics().getHeight() * getNumItems();
-				}
 				g2d.setColor(Palette.PF_BLACK_100.getAWTColor());
 				g2d.fillRect(0, 0, rect.width, rect.height);
 				Point adjusted = translateDisplayToImageCoordinates(rect.width, rect.height);
 				render(g2d, adjusted.x, adjusted.y);
 				if (getParent() instanceof ScrolledComposite) {
-					((ScrolledComposite) getParent()).setMinSize(rect.width, rect.height);
+					((ScrolledComposite) getParent()).setMinSize(adjusted.x, adjusted.y);
 				}
 				if (highlightRects != null) {
 					updateHighlightRects();

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/wizards/OnePageWizardDialog.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/wizards/OnePageWizardDialog.java
@@ -150,4 +150,12 @@ public class OnePageWizardDialog extends SizeConstrainedWizardDialog {
 		d.setHeightConstraint(height, height);
 		return d.open();
 	}
+
+	public static int openAndHideCancelButton(IWizardPage wp, int width, int height) {
+		OnePageWizardDialog d = new OnePageWizardDialog(Display.getCurrent().getActiveShell(), wp);
+		d.setHideCancelButton(true);
+		d.setWidthConstraint(width, width);
+		d.setHeightConstraint(height, height);
+		return d.open();
+	}
 }


### PR DESCRIPTION
This patch addresses the sizing of thread lanes and how they are sized based on different table selections. The previous implementation was a WIP placeholder, and now the lanes are made to fill the canvas. There is also a hardcoded minimum value for the lane height, which may be useful later to increase the lanes for accessibility reasons.

Additionally, the cancel button has been removed from the table popup.

Before:
![Before](https://user-images.githubusercontent.com/10425301/64291034-40ddba00-cf35-11e9-8593-93555f26e08a.gif)

After:
![After](https://user-images.githubusercontent.com/10425301/64291033-40452380-cf35-11e9-8265-684dce7c72c2.gif)
