### PR TITLE
Make thread names section its own component

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/DataPageToolkit.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/DataPageToolkit.java
@@ -155,6 +155,7 @@ import org.openjdk.jmc.ui.column.TableSettings.ColumnSettings;
 import org.openjdk.jmc.ui.handlers.ActionToolkit;
 import org.openjdk.jmc.ui.handlers.MCContextMenuManager;
 import org.openjdk.jmc.ui.misc.ChartCanvas;
+import org.openjdk.jmc.ui.misc.ChartTextCanvas;
 import org.openjdk.jmc.ui.misc.CompositeToolkit;
 import org.openjdk.jmc.ui.misc.DisplayToolkit;
 import org.openjdk.jmc.ui.misc.FilterEditor;
@@ -312,6 +313,10 @@ public class DataPageToolkit {
 		setChart(canvas, chart, selectionListener, null);
 	}
 
+	public static void setChart(ChartTextCanvas canvas, XYChart chart, Consumer<IItemCollection> selectionListener) {
+		setChart(canvas, chart, selectionListener, null);
+	}
+
 	public static void setChart(
 		ChartCanvas canvas, XYChart chart, Consumer<IItemCollection> selectionListener,
 		Consumer<IRange<IQuantity>> selectRangeConsumer) {
@@ -328,6 +333,37 @@ public class DataPageToolkit {
 					chart.setVisibleRange(selectionStart, selectionEnd);
 				}
 				canvas.redrawChart();
+			}
+		});
+
+		canvas.setSelectionListener(() -> {
+			selectionListener.accept(ItemRow.getRangeSelection(chart, JfrAttributes.LIFETIME));
+			IQuantity start = chart.getSelectionStart();
+			IQuantity end = chart.getSelectionEnd();
+			if (selectRangeConsumer != null) {
+				selectRangeConsumer
+						.accept(start != null && end != null ? QuantityRange.createWithEnd(start, end) : null);
+			}
+		});
+		canvas.setChart(chart);
+	}
+
+	public static void setChart(
+		ChartTextCanvas canvas, XYChart chart, Consumer<IItemCollection> selectionListener,
+		Consumer<IRange<IQuantity>> selectRangeConsumer) {
+		IMenuManager contextMenu = canvas.getContextMenu();
+		contextMenu.removeAll();
+		canvas.getContextMenu().add(new Action(Messages.CHART_ZOOM_TO_SELECTED_RANGE) {
+			@Override
+			public void run() {
+				IQuantity selectionStart = chart.getSelectionStart();
+				IQuantity selectionEnd = chart.getSelectionEnd();
+				if (selectionStart == null || selectionEnd == null) {
+					chart.clearVisibleRange();
+				} else {
+					chart.setVisibleRange(selectionStart, selectionEnd);
+				}
+				canvas.redrawChartText();
 			}
 		});
 

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ThreadsPage.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ThreadsPage.java
@@ -359,6 +359,7 @@ public class ThreadsPage extends AbstractDataPage {
 							.getSelectedRows((object, items) -> lanes.buildThreadRenderer(object, items))
 							.collect(Collectors.toList());
 					chartCanvas.setNumItems(this.threadRows.size());
+					textCanvas.setNumItems(this.threadRows.size());
 					this.isChartModified = false;
 					if (this.isChartMenuActionsInit) {
 						setResetChartActionEnablement(false);


### PR DESCRIPTION
This PR moves the thread name portion of the chart to it's own component.

There are a couple of regressions that will need to be addressed in the future, however this is in a workable state that will make it easier to fulfil the rest of the features required for the ui.

The main regressions are the lane selections, where now clicking on the thread name highlights a select portion of the lane, and not the entire lane as previously. This is due to the listener on the text canvas applying the mouse location to the chart selection, e.g., selecting a thread name at point x=40 on the text canvas will apply a selection of x=40 on the chart canvas. This primarily has to do with the duplicate implementation, however should be not too difficult to address in the future. Additionally ESC to reset doesn't work on the thread names, and double click to unhighlight the lane is a bit finicky, again because of the click being translated onto the chart canvas as well. I have a short patch to address some of this, however more cleanup will have to be done at a later date.