### PR TITLE
fix some of the thread name & lane selection post-text canvas patch

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ChartAndPopupTableUI.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ChartAndPopupTableUI.java
@@ -92,7 +92,7 @@ abstract class ChartAndPopupTableUI implements IPageUI {
 	private static final String TABLE = "table"; //$NON-NLS-1$
 	private static final String CHART = "chart"; //$NON-NLS-1$
 	private static final String SELECTED = "selected"; //$NON-NLS-1$
-	private static final int X_OFFSET = 180;
+	private static final int X_OFFSET = 0;
 	private final IItemFilter pageFilter;
 	protected final StreamModel model;
 	protected CheckboxTableViewer chartLegend;
@@ -176,6 +176,8 @@ abstract class ChartAndPopupTableUI implements IPageUI {
 		Composite chartAndTextContainer = toolkit.createComposite(chartAndTimelineContainer);
 		gridLayout = new GridLayout(2, false);
 		gridLayout.horizontalSpacing = 0;
+		gridLayout.marginWidth = 0;
+		gridLayout.marginHeight = 0;
 		chartAndTextContainer.setLayout(gridLayout);
 		chartAndTextContainer.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
 
@@ -204,7 +206,7 @@ abstract class ChartAndPopupTableUI implements IPageUI {
 		scText.setExpandHorizontal(true);
 		scText.setExpandVertical(true);
 
-		timelineCanvas = new TimelineCanvas(chartAndTimelineContainer, X_OFFSET);
+		timelineCanvas = new TimelineCanvas(chartAndTimelineContainer, 180);
 		GridData gridData = new GridData(SWT.FILL, SWT.DEFAULT, true, false);
 		gridData.heightHint = 40; // TODO: replace with constant
 		timelineCanvas.setLayoutData(gridData);
@@ -222,7 +224,7 @@ abstract class ChartAndPopupTableUI implements IPageUI {
 		PersistableSashForm.loadState(sash, state.getChild(SASH));
 		DataPageToolkit.createChartTimestampTooltip(chartCanvas);
 
-		chart = new XYChart(pageContainer.getRecordingRange(), RendererToolkit.empty(), 180, timelineCanvas);
+		chart = new XYChart(pageContainer.getRecordingRange(), RendererToolkit.empty(), X_OFFSET, timelineCanvas);
 		DataPageToolkit.setChart(chartCanvas, chart, pageContainer::showSelection);
 		DataPageToolkit.setChart(textCanvas, chart, pageContainer::showSelection);
 		SelectionStoreActionToolkit.addSelectionStoreRangeActions(pageContainer.getSelectionStore(), chart,

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/XYChart.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/XYChart.java
@@ -197,7 +197,6 @@ public class XYChart {
 		rendererResult = rendererRoot.render(context, xBucketRange, axisHeight);
 		AffineTransform oldTransform = context.getTransform();
 
-		rowColorCounter = 0;
 		context.setTransform(oldTransform);
 		if (!selectedRows.isEmpty()) {
 			renderSelectionChart(context, rendererResult);
@@ -218,10 +217,6 @@ public class XYChart {
 			renderSelectionText(context, rendererResult);
 			context.setTransform(oldTransform);
 		}
-		// .. and finally a semitransparent axis line again.
-		context.setPaint(new Color(0, 0, 0, 64));
-		context.drawLine(0, axisHeight - 1, axisWidth - 1, axisHeight - 1);
-		renderRangeIndication(context, axisHeight + 25);
 	}
 
 	private void renderSelectionText(Graphics2D context, IRenderedRow row) {
@@ -282,7 +277,7 @@ public class XYChart {
 				context.drawLine(0, height - 1, axisWidth -15, height - 1);
 				int y = ((height - context.getFontMetrics().getHeight()) / 2) + context.getFontMetrics().getAscent();
 				int charsWidth = context.getFontMetrics().charsWidth(text.toCharArray(), 0, text.length());
-				if (charsWidth > xOffset) {
+				if (xOffset > 0 && charsWidth > xOffset) {
 					float fitRatio = ((float) xOffset) / (charsWidth
 							+ context.getFontMetrics().charsWidth(ELLIPSIS.toCharArray(), 0, ELLIPSIS.length()));
 					text = text.substring(0, ((int) (text.length() * fitRatio)) - 1) + ELLIPSIS;


### PR DESCRIPTION
The X_OFFSET value of 180 was still being used, but now that the thread names are in their own component both the textcanvas and chartcanvas can use 0.

Also it's not pretty, but some of the textcanvas code has been commented out that was causing selection issues and sizing issues with the timeline canvas. Because it's wired up the same was as the chartcanvas, when hovering the thread names the chart gets up dated too, so many events were firing twice. There are still a couple issues lying around but this restores a decent bit of the functionality.