### PR TITLE
Fix lane selection from the thread name component

### DIFF
--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/XYChart.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/XYChart.java
@@ -400,10 +400,10 @@ public class XYChart {
 	}
 
 	public boolean select(int x1, int x2, int y1, int y2, boolean clear) {
-		int xStart = Math.min(x1, x2) - xOffset;
-		int xEnd = Math.max(x1, x2) - xOffset;
+		int xStart = Math.min(x1, x2);
+		int xEnd = Math.max(x1, x2);
 
-		if (xBucketRange != null && (xEnd >= 0)) {
+		if (xBucketRange != null && (xEnd != xStart)) {
 			return select(xBucketRange.getQuantityAtPixel(Math.max(0, xStart)), xBucketRange.getQuantityAtPixel(xEnd),
 					y1, y2, clear);
 		} else {

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartTextCanvas.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartTextCanvas.java
@@ -175,7 +175,7 @@ public class ChartTextCanvas extends Canvas {
 				selectionIsClick = false;
 			}
 			if (!selectionIsClick) {
-				select((int) (selectionStartX / xScale), (int) (x / xScale), (int) (selectionStartY / yScale),
+				select((int) (selectionStartX / xScale), (int) (selectionStartX / xScale), (int) (selectionStartY / yScale),
 						(int) (y / yScale), true);
 			}
 		}


### PR DESCRIPTION
This patch addresses the lane selection issues addressed in  https://github.com/aptmac/jmc/pull/4#issue-316027729.

Specifically, it fixes how selecting a lane via clicking on a thread name, or multiple lanes via dragging the mouse over multiple thread names,  highlights a select portion of a thread name's corresponding lane instead of an entire one.
