### PR TITLE
Fix reset highlighting on text canvas with ESC key

### DIFF
--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartCanvas.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartCanvas.java
@@ -352,6 +352,7 @@ public class ChartCanvas extends Canvas {
 						selectionListener.run();
 					}
 					redrawChart();
+					redrawChartText();
 					break;
 				case SWT.ARROW_RIGHT:
 					pan(10);

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartTextCanvas.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartTextCanvas.java
@@ -280,6 +280,7 @@ public class ChartTextCanvas extends Canvas {
 						selectionListener.run();
 					}
 					redrawChart();
+					redrawChartText();
 					break;
 				default:
 					// Ignore


### PR DESCRIPTION
This patch resets lane highlighting on the text canvas when lanes are deselected using the ESC key.

This issue is addressed in https://github.com/aptmac/jmc/pull/4#issue-316027729.