### PR TITLE
Introduce range-based zoom functionality

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ChartAndPopupTableUI.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ChartAndPopupTableUI.java
@@ -317,6 +317,7 @@ abstract class ChartAndPopupTableUI implements IPageUI {
 	private void onSetRange(Boolean useRange) {
 		IRange<IQuantity> range = useRange ? timeRange : pageContainer.getRecordingRange();
 		chart.setVisibleRange(range.getStart(), range.getEnd());
+		chart.resetZoomFactor();
 		cdcb.resetZoomScale();
 		buildChart();
 	}

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ChartAndPopupTableUI.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ChartAndPopupTableUI.java
@@ -117,8 +117,8 @@ abstract class ChartAndPopupTableUI implements IPageUI {
 	private Composite hiddenTableContainer;
 
 	private TimelineCanvas timelineCanvas;
-	public ChartFilterControlBar filterBar;
-	private ChartDisplayControlBar cdcb;
+	protected ChartFilterControlBar filterBar;
+	private ChartDisplayControlBar displayBar;
 
 	ChartAndPopupTableUI(IItemFilter pageFilter, StreamModel model, Composite parent, FormToolkit toolkit,
 			IPageContainer pageContainer, IState state, String sectionTitle, IItemFilter tableFilter, Image icon,
@@ -250,7 +250,7 @@ abstract class ChartAndPopupTableUI implements IPageUI {
 		timelineCanvas.setLayoutData(gridData);
 
 		// add the display bar to the right of the chart scrolled composite
-		cdcb = new ChartDisplayControlBar(graphContainer);
+		displayBar = new ChartDisplayControlBar(graphContainer);
 
 		allChartSeriesActions = initializeChartConfiguration(state);
 		IState chartState = state.getChild(CHART);
@@ -262,7 +262,7 @@ abstract class ChartAndPopupTableUI implements IPageUI {
 		PersistableSashForm.loadState(sash, state.getChild(SASH));
 		DataPageToolkit.createChartTimestampTooltip(chartCanvas);
 
-		chart = new XYChart(pageContainer.getRecordingRange(), RendererToolkit.empty(), X_OFFSET, timelineCanvas, filterBar);
+		chart = new XYChart(pageContainer.getRecordingRange(), RendererToolkit.empty(), X_OFFSET, timelineCanvas, filterBar, displayBar);
 		DataPageToolkit.setChart(chartCanvas, chart, pageContainer::showSelection);
 		DataPageToolkit.setChart(textCanvas, chart, pageContainer::showSelection);
 		SelectionStoreActionToolkit.addSelectionStoreRangeActions(pageContainer.getSelectionStore(), chart,
@@ -270,13 +270,12 @@ abstract class ChartAndPopupTableUI implements IPageUI {
 				chartCanvas.getContextMenu());
 		buildChart();
 
-		// Temp: Pass the chart into the toolbars for information retrieval
-		cdcb.setChartCanvas(chartCanvas);
-		cdcb.setTextCanvas(textCanvas);
-		cdcb.setChart(chart);
-		cdcb.createZoomPan(zoomPanContainer);
-		chartCanvas.setZoomToSelectionListener(() -> cdcb.zoomToSelection());
-		chartCanvas.setZoomOnClickListener(()-> cdcb.setZoomOnClickData());
+		// Wire-up the chart & text canvases to the filter and display bars
+		displayBar.setChartCanvas(chartCanvas);
+		displayBar.setTextCanvas(textCanvas);
+		displayBar.setChart(chart);
+		chartCanvas.setZoomToSelectionListener(() -> displayBar.zoomToSelection());
+		chartCanvas.setZoomOnClickListener(()-> displayBar.setZoomOnClickData());
 
 		if (chartState != null) {
 			final String legendSelection = chartState.getAttribute(SELECTED);
@@ -318,7 +317,7 @@ abstract class ChartAndPopupTableUI implements IPageUI {
 		IRange<IQuantity> range = useRange ? timeRange : pageContainer.getRecordingRange();
 		chart.setVisibleRange(range.getStart(), range.getEnd());
 		chart.resetZoomFactor();
-		cdcb.resetZoomScale();
+		displayBar.resetZoomScale();
 		buildChart();
 	}
 

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ChartAndPopupTableUI.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ChartAndPopupTableUI.java
@@ -274,6 +274,7 @@ abstract class ChartAndPopupTableUI implements IPageUI {
 		displayBar.setChartCanvas(chartCanvas);
 		displayBar.setTextCanvas(textCanvas);
 		displayBar.setChart(chart);
+		displayBar.createZoomPan(zoomPanContainer);
 		chartCanvas.setZoomToSelectionListener(() -> displayBar.zoomToSelection());
 		chartCanvas.setZoomOnClickListener(()-> displayBar.setZoomOnClickData());
 

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/ChartDisplayControlBar.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/ChartDisplayControlBar.java
@@ -113,6 +113,7 @@ public class ChartDisplayControlBar extends Composite {
 				UIPlugin.getDefault().getImage(UIPlugin.ICON_FA_ZOOM_OUT).getImageData(), 0, 0));
 
 		selectionBtn = new Button(this, SWT.TOGGLE);
+		selectionBtn.setLayoutData(new GridData(SWT.CENTER, SWT.CENTER, false, false));
 		selectionBtn.setImage(UIPlugin.getDefault().getImage(UIPlugin.ICON_FA_SELECTION));
 		selectionBtn.setSelection(true);
 		selectionBtn.addListener(SWT.Selection, new Listener() {
@@ -128,6 +129,7 @@ public class ChartDisplayControlBar extends Composite {
 		// SPACE
 
 		zoomInBtn = new Button(this, SWT.TOGGLE);
+		zoomInBtn.setLayoutData(new GridData(SWT.CENTER, SWT.CENTER, false, false));
 		zoomInBtn.setImage(UIPlugin.getDefault().getImage(UIPlugin.ICON_FA_ZOOM_IN));
 		zoomInBtn.setSelection(false);
 		zoomInBtn.addListener(SWT.Selection,  new Listener() {
@@ -147,10 +149,10 @@ public class ChartDisplayControlBar extends Composite {
 
 		scale = new Scale(this, SWT.VERTICAL);
 		scale.setMinimum(0);
-		scale.setMaximum(30);
+		scale.setMaximum(35);
 		scale.setIncrement(1);
-		scale.setSelection(30);
-		scale.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+		scale.setSelection(35);
+		scale.setLayoutData(new GridData(SWT.CENTER, SWT.FILL, true, true));
 		scale.setEnabled(false);
 //		scale.addListener(SWT.Selection, new Listener() {
 //			@Override
@@ -162,10 +164,11 @@ public class ChartDisplayControlBar extends Composite {
 //		});
 
 		text = new Text(this, SWT.BORDER | SWT.READ_ONLY | SWT.SINGLE);
-		text.setText(Integer.toString(0));
-		text.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, false));
+		text.setLayoutData(new GridData(SWT.CENTER, SWT.CENTER, false, false));
+		setZoomPercentageText(100);
 
 		zoomOutBtn = new Button(this, SWT.TOGGLE);
+		zoomOutBtn.setLayoutData(new GridData(SWT.CENTER, SWT.CENTER, false, false));
 		zoomOutBtn.setImage(UIPlugin.getDefault().getImage(UIPlugin.ICON_FA_ZOOM_OUT));
 		zoomOutBtn.setSelection(false);
 		zoomOutBtn.addListener(SWT.Selection,  new Listener() {
@@ -210,6 +213,10 @@ public class ChartDisplayControlBar extends Composite {
 		});
 		buttonGroup.add(scaleToFitBtn);
 
+	}
+
+	public void setZoomPercentageText(double zoom) {
+		text.setText(String.format("%.2f %s", zoom, "%"));
 	}
 
 	private void changeCursor(String cursorName) {
@@ -280,7 +287,7 @@ public class ChartDisplayControlBar extends Composite {
 			chart.zoom(currentZoomValue - zoomValue);
 			zoomValue = currentZoomValue;
 			int value = scale.getMaximum() - scale.getSelection() + scale.getMinimum();
-			text.setText(Integer.toString(value));
+//			text.setText(Integer.toString(value));
 
 			chartCanvas.redrawChart();
 	}
@@ -487,6 +494,6 @@ public class ChartDisplayControlBar extends Composite {
 	public void resetZoomScale() {
 		this.scale.setSelection(scale.getMaximum());
 		zoomValue = 0;
-		text.setText(Integer.toString(0));
+		setZoomPercentageText(100);
 	}
 }

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/ChartDisplayControlBar.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/ChartDisplayControlBar.java
@@ -189,6 +189,7 @@ public class ChartDisplayControlBar extends Composite {
 		// SPACE
 
 		zoomPanBtn = new Button(this, SWT.TOGGLE);
+		zoomPanBtn.setLayoutData(new GridData(SWT.CENTER, SWT.CENTER, false, false));
 		zoomPanBtn.setImage(UIPlugin.getDefault().getImage(UIPlugin.ICON_FA_ZOOM_PAN));
 		zoomPanBtn.setSelection(false);
 		zoomPanBtn.addListener(SWT.Selection, new Listener() {
@@ -200,14 +201,16 @@ public class ChartDisplayControlBar extends Composite {
 		buttonGroup.add(zoomPanBtn);
 
 		Button scaleToFitBtn = new Button(this, SWT.PUSH);
+		scaleToFitBtn.setLayoutData(new GridData(SWT.CENTER, SWT.CENTER, false, false));
 		scaleToFitBtn.setImage(UIPlugin.getDefault().getImage(UIPlugin.ICON_FA_SCALE_TO_FIT));
 		scaleToFitBtn.setSelection(false);
 		scaleToFitBtn.addListener(SWT.Selection, new Listener() {
 
 			@Override
 			public void handleEvent(Event event) {
-				setButtonSelectionStates(scaleToFitBtn, null);
-				changeCursor(DEFAULT_CURSOR);
+				resetZoomScale();
+				chart.resetTimeline();
+				chartCanvas.redrawChart();
 			}
 
 		});
@@ -217,6 +220,24 @@ public class ChartDisplayControlBar extends Composite {
 
 	public void setZoomPercentageText(double zoom) {
 		text.setText(String.format("%.2f %s", zoom, "%"));
+	}
+
+	public void setScaleValue(int value) {
+		scale.setSelection(scale.getMaximum() - value);
+	}
+
+	public void increaseScaleValue() {
+		scale.setSelection(scale.getSelection() - 1);
+	}
+
+	public void decreaseScaleValue() {
+		scale.setSelection(scale.getSelection() + 1);
+	}
+
+	public void resetZoomScale() {
+		scale.setSelection(scale.getMaximum());
+		zoomValue = 0;
+		setZoomPercentageText(100);
 	}
 
 	private void changeCursor(String cursorName) {
@@ -274,21 +295,22 @@ public class ChartDisplayControlBar extends Composite {
 		}
 
 		private void doZoomInOut(int zoomAmount) {
-			DisplayToolkit.inDisplayThread().execute( () -> zoomInOut(zoomAmount));;
+			DisplayToolkit.inDisplayThread().execute( () -> zoomInOut(zoomAmount));
 		}
 	}
 
 	private void zoomInOut(int zoomAmount) {
-			int currentZoomValue = getZoomValueByScale();
-			if(currentZoomValue == zoomValue) {
-				scale.setSelection(scale.getSelection() - zoomAmount*scale.getIncrement());
-				currentZoomValue = getZoomValueByScale();
-			}
-			chart.zoom(currentZoomValue - zoomValue);
-			zoomValue = currentZoomValue;
-			int value = scale.getMaximum() - scale.getSelection() + scale.getMinimum();
+//			int currentZoomValue = getZoomValueByScale();
+//			if(currentZoomValue == zoomValue) {
+//				scale.setSelection(scale.getSelection() - zoomAmount*scale.getIncrement());
+//				currentZoomValue = getZoomValueByScale();
+//			}
+//			chart.zoom(currentZoomValue - zoomValue);
+//			zoomValue = currentZoomValue;
+//			int value = scale.getMaximum() - scale.getSelection() + scale.getMinimum();
 //			text.setText(Integer.toString(value));
-
+			scale.setSelection(scale.getSelection() - zoomAmount);
+			chart.zoom(zoomAmount);
 			chartCanvas.redrawChart();
 	}
 
@@ -336,6 +358,7 @@ public class ChartDisplayControlBar extends Composite {
 			public void mouseDown(MouseEvent e) {
 				if (e.button == 1 && zoomRect.contains(e.x, e.y)) {
 					isPan = true;
+					chart.setIsZoomPanDrag(isPan);
 					currentSelection = translateDisplayToImageCoordinates(e.x, e.y);
 				}
 			}
@@ -343,6 +366,7 @@ public class ChartDisplayControlBar extends Composite {
 			@Override
 			public void mouseUp(MouseEvent e) {
 				isPan = false;
+				chart.setIsZoomPanDrag(isPan);
 			}
 
 			@Override
@@ -489,11 +513,5 @@ public class ChartDisplayControlBar extends Composite {
 			return offset + (int) (visibliyRatio * totalLength);
 		}
 
-	}
-
-	public void resetZoomScale() {
-		this.scale.setSelection(scale.getMaximum());
-		zoomValue = 0;
-		setZoomPercentageText(100);
 	}
 }

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/ChartDisplayControlBar.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/ChartDisplayControlBar.java
@@ -48,7 +48,7 @@ public class ChartDisplayControlBar extends Composite {
 	private XYChart chart;
 	private ChartCanvas chartCanvas;
 	private ChartTextCanvas textCanvas;
-	private List<Button> buttonGroup = new ArrayList<>();;
+	private List<Button> buttonGroup = new ArrayList<>();
 	private Button zoomInBtn;
 	private Button zoomOutBtn;
 	private Button selectionBtn;
@@ -147,21 +147,21 @@ public class ChartDisplayControlBar extends Composite {
 
 		scale = new Scale(this, SWT.VERTICAL);
 		scale.setMinimum(0);
-		scale.setMaximum(50);
+		scale.setMaximum(30);
 		scale.setIncrement(1);
-		scale.setSelection(50);
+		scale.setSelection(30);
 		scale.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
-		scale.addListener(SWT.Selection, new Listener() {
-			@Override
-			public void handleEvent(Event event) {
-				setButtonSelectionStates(null, null);
-				changeCursor(DEFAULT_CURSOR);
-				zoomInOut(getZoomValueByScale() - zoomValue);
-			}
-		});
+		scale.setEnabled(false);
+//		scale.addListener(SWT.Selection, new Listener() {
+//			@Override
+//			public void handleEvent(Event event) {
+//				setButtonSelectionStates(null);
+//				changeCursor(DEFAULT_CURSOR);
+//				zoomInOut(getZoomValueByScale() - zoomValue);
+//			}
+//		});
 
-		text = new Text(this, SWT.BORDER | SWT.SINGLE);
-		text.setEditable(false);
+		text = new Text(this, SWT.BORDER | SWT.READ_ONLY | SWT.SINGLE);
 		text.setText(Integer.toString(0));
 		text.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, false));
 
@@ -170,7 +170,7 @@ public class ChartDisplayControlBar extends Composite {
 		zoomOutBtn.setSelection(false);
 		zoomOutBtn.addListener(SWT.Selection,  new Listener() {
 			@Override
-			public void handleEvent(Event event) {
+			public void handleEvent(Event e) {
 				if (scale.getSelection() < scale.getMaximum()) {
 					setButtonSelectionStates(zoomOutBtn, zoomPanBtn);
 					changeCursor(ZOOM_OUT_CURSOR);
@@ -485,8 +485,8 @@ public class ChartDisplayControlBar extends Composite {
 	}
 
 	public void resetZoomScale() {
-//		this.scale.setSelection(scale.getMaximum());
-//		zoomValue = 0;
-//		text.setText(Integer.toString(0));
+		this.scale.setSelection(scale.getMaximum());
+		zoomValue = 0;
+		text.setText(Integer.toString(0));
 	}
 }

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/ChartFilterControlBar.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/ChartFilterControlBar.java
@@ -31,8 +31,6 @@ public class ChartFilterControlBar extends Composite {
 
 		timeFilter = new TimeFilter(this, recordingRange, resetListener);
 		timeFilter.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, false, false));
-
-		// Thread State Selection button current added in ThreadsPage
 	}
 
 	public void setChart(XYChart chart) {

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/TimeDisplay.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/TimeDisplay.java
@@ -67,7 +67,6 @@ public class TimeDisplay extends Composite {
 				return displayTime;
 			}
 			if (isFormatValid()) {
-				LinearUnit linearUnit;
 				IQuantity time = currentTime;
 				Matcher m = digitPattern.matcher(timeText.getText());
 				int i = 0;
@@ -76,23 +75,19 @@ public class TimeDisplay extends Composite {
 					switch(i) {
 					case 0:
 						value = value - currentCalendar.get(Calendar.HOUR);
-						linearUnit = UnitLookup.HOUR;
-						time = time.in(UnitLookup.EPOCH_NS).add(linearUnit.quantity(value).in(UnitLookup.NANOSECOND));
+						time = time.in(UnitLookup.EPOCH_NS).add(UnitLookup.HOUR.quantity(value).in(UnitLookup.NANOSECOND));
 						break;
 					case 1:
 						value = value - currentCalendar.get(Calendar.MINUTE);
-						linearUnit = UnitLookup.MINUTE;
-						time = time.in(UnitLookup.EPOCH_NS).add(linearUnit.quantity(value).in(UnitLookup.NANOSECOND));
+						time = time.in(UnitLookup.EPOCH_NS).add(UnitLookup.MINUTE.quantity(value).in(UnitLookup.NANOSECOND));
 						break;
 					case 2:
 						value = value - currentCalendar.get(Calendar.SECOND);
-						linearUnit = UnitLookup.SECOND;
-						time = time.in(UnitLookup.EPOCH_NS).add(linearUnit.quantity(value).in(UnitLookup.NANOSECOND));
+						time = time.in(UnitLookup.EPOCH_NS).add(UnitLookup.SECOND.quantity(value).in(UnitLookup.NANOSECOND));
 						break;
 					case 3:
 						value = value - currentCalendar.get(Calendar.MILLISECOND);
-						linearUnit = UnitLookup.MILLISECOND;
-						time = time.in(UnitLookup.EPOCH_NS).add(linearUnit.quantity(value).in(UnitLookup.NANOSECOND));
+						time = time.in(UnitLookup.EPOCH_NS).add(UnitLookup.MILLISECOND.quantity(value).in(UnitLookup.NANOSECOND));
 						break;
 					}
 					i++;
@@ -140,12 +135,10 @@ public class TimeDisplay extends Composite {
 			int i = 0;
 			while(m.find()) {
 				int value = Integer.parseInt(m.group());
-				if (i == 0) {
-					if (value > 23) { return false; }
-				} else if (i == 1 && i == 2) {
-					if (value > 59) { return false; }
-				} else if (i == 3){
-					// don't have to do anything
+				if (i == 0 && value >= 24) {
+					return false;
+				} else if ((i == 1 || i == 2) && value >= 60) {
+					return false;
 				}
 				i++;
 			}

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/TimeDisplay.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/TimeDisplay.java
@@ -13,7 +13,6 @@ import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Text;
 import org.openjdk.jmc.common.unit.IQuantity;
-import org.openjdk.jmc.common.unit.LinearUnit;
 import org.openjdk.jmc.common.unit.UnitLookup;
 import org.openjdk.jmc.ui.common.PatternFly.Palette;
 
@@ -30,7 +29,7 @@ public class TimeDisplay extends Composite {
 
 		public TimeDisplay(Composite parent) {
 			super(parent, SWT.NO_BACKGROUND);
-			this.setLayout(new GridLayout(1, true));
+			this.setLayout(new GridLayout());
 			timeText = new Text(this, SWT.SEARCH | SWT.SINGLE);
 			timeText.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, false));
 			timeText.setTextLimit(12);
@@ -38,7 +37,7 @@ public class TimeDisplay extends Composite {
 				@Override
 				public void modifyText(ModifyEvent e) {
 					displayTime = null;
-					if (isFormatValid()) {
+					if (isFormatValid() && isValidTime()) {
 						timeText.setForeground(Palette.PF_BLACK.getSWTColor());
 					} else {
 						timeText.setForeground(Palette.PF_RED_100.getSWTColor());
@@ -66,7 +65,7 @@ public class TimeDisplay extends Composite {
 				formatTimeString(convertEpochToCalendar(displayTime.in(UnitLookup.EPOCH_MS).longValue()));
 				return displayTime;
 			}
-			if (isFormatValid()) {
+			if (isFormatValid() && isValidTime()) {
 				IQuantity time = currentTime;
 				Matcher m = digitPattern.matcher(timeText.getText());
 				int i = 0;
@@ -118,18 +117,21 @@ public class TimeDisplay extends Composite {
 		/**
 		 * Verify that the time string inside the text widget matches the
 		 * expected time format of HH:mm:ss:SSS
+		 * @return true if the text corresponds to a HH:mm:ss:SSS format
 		 */
-		public boolean isFormatValid() {
+		private boolean isFormatValid() {
 			if (!timePattern.matcher(timeText.getText()).matches()) {
 				// not in HH:mm:ss:SSS format
-				return false;
-			} else if (!isValidTime()) {
-				// exceeds the numerical constraints for time units
 				return false;
 			}
 			return true;
 		}
 
+		/**
+		 * Verify that the string inside the text widget is a valid
+		 * 24-hour clock time
+		 * @return true if the text corresponds to a valid 24-hour time
+		 */
 		private boolean isValidTime() {
 			Matcher m = digitPattern.matcher(timeText.getText());
 			int i = 0;

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/TimeDisplay.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/TimeDisplay.java
@@ -119,7 +119,7 @@ public class TimeDisplay extends Composite {
 		 * expected time format of HH:mm:ss:SSS
 		 * @return true if the text corresponds to a HH:mm:ss:SSS format
 		 */
-		private boolean isFormatValid() {
+		protected boolean isFormatValid() {
 			if (!timePattern.matcher(timeText.getText()).matches()) {
 				// not in HH:mm:ss:SSS format
 				return false;

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartCanvas.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartCanvas.java
@@ -417,9 +417,7 @@ public class ChartCanvas extends Canvas {
 		Selector selector = new Selector();
 		addMouseListener(selector);
 		addMouseMoveListener(selector);
-//		addMouseTrackListener(selector);
 		FocusTracker.enableFocusTracking(this);
-//		addListener(SWT.MouseVerticalWheel, new Zoomer());
 		addKeyListener(new KeyNavigator());
 		aaListener = new AntiAliasingListener();
 		UIPlugin.getDefault().getPreferenceStore().addPropertyChangeListener(aaListener);
@@ -427,9 +425,12 @@ public class ChartCanvas extends Canvas {
 		if (Environment.getOSType() == OSType.WINDOWS) {
 			addMouseTrackListener(new WheelStealingZoomer());
 		}
-		if (getParent() instanceof ScrolledComposite) {
+		if (getParent() instanceof ScrolledComposite) { // JFR Threads Page
 			((ScrolledComposite) getParent()).getVerticalBar()
 				.addListener(SWT.Selection, e -> vBarScroll());
+		} else {
+			addMouseTrackListener(selector);
+			addListener(SWT.MouseVerticalWheel, new Zoomer());
 		}
 	}
 
@@ -540,7 +541,9 @@ public class ChartCanvas extends Canvas {
 		}
 		if (!newRects.equals(highlightRects)) {
 			highlightRects = newRects;
-			textCanvas.syncHighlightedRectangles(highlightRects);
+			if (textCanvas != null) {
+				textCanvas.syncHighlightedRectangles(highlightRects);
+			}
 			redraw();
 		}
 	}


### PR DESCRIPTION
The current zoom functionality can have discrepancies between magnitude of zooming in versus zooming out. e.g., one zoom step in != one zoom step out. This is because it zooms in, saves the new start/end, zooms in based on those new points, and so on. This results in a zoom pattern that cannot be recreated on the way back.

This new implementation zooms in at a fixed percentage each time. Initially, it zooms based on 5% of the total recording time, until it reaches a point where it can no longer do so, and then it changes the zoom power to 2.5%, then 1.25%, etc. These changes in power are held in a stack so they can be recreated on the zoom out. Additionally, because it is predictable there is a function that can figure out how many steps were taken during a selection or time filter based zoom, and adjust the display bar scale accordingly. Currently the implementation could use some cleaning up and the selection zoom calculation function doesn't account for the steps in zoom power, but this will be added.

The display bar also shows the percent zoom now, although it probably isn't correct. The text label itself is rather long too so it isn't as visually appealing as before, I'll have to look into this.

![2019-09-30-range-zoom](https://user-images.githubusercontent.com/10425301/65916713-d6892f80-e3a3-11e9-95c5-8359fbe91539.gif)
