### PR TITLE
Prevent zoom in on mouse down when zooming to selection

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ChartAndPopupTableUI.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ChartAndPopupTableUI.java
@@ -276,7 +276,7 @@ abstract class ChartAndPopupTableUI implements IPageUI {
 		displayBar.setChart(chart);
 		displayBar.createZoomPan(zoomPanContainer);
 		chartCanvas.setZoomToSelectionListener(() -> displayBar.zoomToSelection());
-		chartCanvas.setZoomOnClickListener(()-> displayBar.setZoomOnClickData());
+		chartCanvas.setZoomOnClickListener(mouseDown -> displayBar.zoomOnClick(mouseDown));
 
 		if (chartState != null) {
 			final String legendSelection = chartState.getAttribute(SELECTED);

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/ChartDisplayControlBar.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/ChartDisplayControlBar.java
@@ -75,13 +75,16 @@ public class ChartDisplayControlBar extends Composite {
 		parent.setVisible(false);
 	}
 
-	public void setZoomOnClickData() {
+	public void zoomOnClick(Boolean mouseDown) {
 		boolean shouldZoom = zoomInBtn.getSelection() || zoomOutBtn.getSelection() ;
 		if (shouldZoom) {
-			int zoomAmount = zoomInBtn.getSelection() ? 1 : -1;
-			chart.clearSelection();
-			zoomInOut(zoomAmount);
-			textCanvas.redrawChartText();
+			if (mouseDown) {
+				chart.clearSelection();
+			} else {
+				int zoomAmount = zoomInBtn.getSelection() ? ZOOM_AMOUNT : -ZOOM_AMOUNT;
+				zoomInOut(zoomAmount);
+				textCanvas.redrawChartText();
+			}
 		}
 	}
 
@@ -93,7 +96,7 @@ public class ChartDisplayControlBar extends Composite {
 				chart.clearVisibleRange();
 			} else {
 				chart.setVisibleRange(selectionStart, selectionEnd);
-			chartCanvas.redrawChart();
+				chartCanvas.redrawChart();
 			}
 		}
 	}

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartCanvas.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartCanvas.java
@@ -37,6 +37,7 @@ import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.util.IPropertyChangeListener;
@@ -183,6 +184,9 @@ public class ChartCanvas extends Canvas {
 				highlightSelectionStart = new Point(selectionStartX, selectionStartY);
 				selectionStartX = -1;
 				selectionStartY = -1;
+				if (selectionIsClick) {
+					notifyZoomOnClickListener(e.button);
+				}
 				if (selectionListener != null) {
 					selectionListener.run();
 					if (zoomToSelectionListener != null && !selectionIsClick) {
@@ -405,11 +409,11 @@ public class ChartCanvas extends Canvas {
 	private boolean awtNeedsRedraw;
 	private Runnable selectionListener;
 	private Runnable zoomToSelectionListener;
+	private Consumer<Boolean> zoomOnClickListener;
 	private IPropertyChangeListener aaListener;
 	private XYChart awtChart;
 	private MCContextMenuManager chartMenu;
 	private ChartTextCanvas textCanvas;
-	private Runnable zoomOnClickListener;
 
 	public ChartCanvas(Composite parent) {
 		super(parent, SWT.NO_BACKGROUND);
@@ -620,10 +624,7 @@ public class ChartCanvas extends Canvas {
 				if (!awtChart.select(p.x, p.x, p.y, p.y, true)) {
 					awtChart.clearSelection();
 				}
-
-				if (zoomOnClickListener != null) {
-					zoomOnClickListener.run();
-				}
+				notifyZoomOnClickListener(SWT.MouseDown);
 			}
 			redrawChart();
 			redrawChartText();
@@ -659,8 +660,14 @@ public class ChartCanvas extends Canvas {
 		this.zoomToSelectionListener = zoomListener;
 	}
 
-	public void setZoomOnClickListener(Runnable clickListener) {
+	public void setZoomOnClickListener(Consumer<Boolean> clickListener) {
 		this.zoomOnClickListener = clickListener;
+	}
+
+	private void notifyZoomOnClickListener(Integer button) {
+		if (zoomOnClickListener != null) {
+			zoomOnClickListener.accept(button == SWT.MouseDown);
+		}
 	}
 
 	private void notifyListener() {


### PR DESCRIPTION
This patch changes the zoom in action, which occurs when the chart is clicked, to be performed after the mouse button has been released instead of when it is first pressed down.  This prevents a zoom in from occurring on the first click of a zoom to selection action. 