### PR TITLE
place the chart and text canvases into a sashform

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ChartAndPopupTableUI.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ChartAndPopupTableUI.java
@@ -127,10 +127,8 @@ abstract class ChartAndPopupTableUI implements IPageUI {
 		this.model = model;
 		this.pageContainer = pageContainer;
 		form = DataPageToolkit.createForm(parent, toolkit, sectionTitle, icon);
-		sash = new SashForm(form.getBody(), SWT.VERTICAL);
-		toolkit.adapt(sash);
 
-		hiddenTableContainer = new Composite(sash, SWT.NONE);
+		hiddenTableContainer = new Composite(form, SWT.NONE);
 		hiddenTableContainer.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
 		hiddenTableContainer.setVisible(false);
 
@@ -140,13 +138,6 @@ abstract class ChartAndPopupTableUI implements IPageUI {
 		tableFilterComponent = FilterComponent.createFilterComponent(hiddenTable.getManager().getViewer().getControl(),
 				hiddenTable.getManager(), tableFilter, model.getItems().apply(pageFilter),
 				pageContainer.getSelectionStore()::getSelections, this::onFilterChange);
-		
-		chartContainer = toolkit.createComposite(sash);
-		GridLayout gridLayout = new GridLayout(1, true);
-		gridLayout.marginWidth = 0;
-		gridLayout.marginHeight = 0;
-		chartContainer.setLayout(gridLayout);
-		chartContainer.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
 
 		/**
 		 * Chart Container (1 column gridlayout) - Contains filter bar & graph container
@@ -157,6 +148,9 @@ abstract class ChartAndPopupTableUI implements IPageUI {
 		 * Full screen Chart Container (1 column gridlayout) - Contains chart container
 		 * Chart and Text Container (2 column gridlayout) - Contains scText and textCanvas) & scChart (and chart canvas)
 		 */
+		chartContainer = toolkit.createComposite(form.getBody());
+		chartContainer.setLayout(new GridLayout());
+		chartContainer.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
 		// Filter Controls
 		Listener resetListener = new Listener() {
 			@Override
@@ -170,7 +164,7 @@ abstract class ChartAndPopupTableUI implements IPageUI {
 
 		// Container to hold the chart (& timeline) and display toolbar
 		Composite graphContainer = toolkit.createComposite(chartContainer);
-		gridLayout = new GridLayout(2, false);
+		GridLayout gridLayout = new GridLayout(2, false);
 		gridLayout.marginWidth = 0;
 		gridLayout.marginHeight = 0;
 		graphContainer.setLayout(gridLayout);
@@ -178,8 +172,7 @@ abstract class ChartAndPopupTableUI implements IPageUI {
 
 		// Container to hold the chart and timeline canvas
 		Composite chartAndTimelineContainer = toolkit.createComposite(graphContainer);
-		gridLayout = new GridLayout(1, false);
-		gridLayout.verticalSpacing = 2;
+		gridLayout = new GridLayout();
 		gridLayout.marginWidth = 0;
 		gridLayout.marginHeight = 0;
 		chartAndTimelineContainer.setLayout(gridLayout);
@@ -202,7 +195,7 @@ abstract class ChartAndPopupTableUI implements IPageUI {
 
 		// Container to hold the chart
 		Composite fullScreenChartContainer = toolkit.createComposite(zoomPanAndChartContainer);
-		fullScreenChartContainer.setLayout(new GridLayout(1,false));
+		fullScreenChartContainer.setLayout(gridLayout);
 		fd = new FormData();
 		fd.right = new FormAttachment(100, -1);
 		fd.top = new FormAttachment(0, 1);
@@ -219,15 +212,19 @@ abstract class ChartAndPopupTableUI implements IPageUI {
 		chartAndTextContainer.setLayout(gridLayout);
 		chartAndTextContainer.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
 
+		sash = new SashForm(chartAndTextContainer, SWT.VERTICAL);
+		sash.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+		toolkit.adapt(sash);
+
 		ScrolledCompositeToolkit sct = new ScrolledCompositeToolkit(Display.getCurrent());
-		ScrolledComposite scText = sct.createScrolledComposite(chartAndTextContainer);
+		ScrolledComposite scText = sct.createScrolledComposite(sash);
 		GridData scTextGd = new GridData(SWT.FILL, SWT.FILL, false, true);
 		scTextGd.widthHint = 180;
 		scText.setLayoutData(scTextGd);
 		textCanvas = new ChartTextCanvas(scText);
 		textCanvas.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, true));
 
-		ScrolledComposite scChart = sct.createScrolledComposite(chartAndTextContainer);
+		ScrolledComposite scChart = sct.createScrolledComposite(sash);
 		scChart.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
 		chartCanvas = new ChartCanvas(scChart);
 		chartCanvas.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
@@ -244,7 +241,7 @@ abstract class ChartAndPopupTableUI implements IPageUI {
 		scText.setExpandHorizontal(true);
 		scText.setExpandVertical(true);
 
-		timelineCanvas = new TimelineCanvas(chartAndTimelineContainer, 180);
+		timelineCanvas = new TimelineCanvas(chartAndTimelineContainer, sash);
 		GridData gridData = new GridData(SWT.FILL, SWT.DEFAULT, true, false);
 		gridData.heightHint = 40; // TODO: replace with constant
 		timelineCanvas.setLayoutData(gridData);

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/AWTChartToolkit.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/AWTChartToolkit.java
@@ -290,10 +290,15 @@ public class AWTChartToolkit {
 		ctx.setTransform(oldTransform);
 	}
 
-	// TODO: add offset attribute instead of hardcoding 180
+	public static void drawAxis(
+			Graphics2D ctx, SubdividedQuantityRange range, int axisPos, boolean labelAhead, int labelLimit,
+			boolean vertical) {
+		drawAxis(ctx, range, axisPos, labelAhead, labelLimit, vertical, 0);
+	}
+
 	public static void drawAxis(
 		Graphics2D ctx, SubdividedQuantityRange range, int axisPos, boolean labelAhead, int labelLimit,
-		boolean vertical) {
+		boolean vertical, int xOffset) {
 		int axisSize = range.getPixelExtent();
 		FontMetrics fm = ctx.getFontMetrics();
 		int textAscent = fm.getAscent();
@@ -306,7 +311,7 @@ public class AWTChartToolkit {
 			drawUpArrow(ctx, axisPos, Y_AXIS_TOP_SPACE, Math.min(ARROW_SIZE, axisSize - 2));
 			labelSpacing = fm.getHeight() - textAscent;
 		} else {
-			ctx.drawLine(0, axisPos, axisSize + 1 + 180, axisPos);
+			ctx.drawLine(0 + xOffset, axisPos, axisSize + xOffset, axisPos);
 			labelSpacing = fm.charWidth(' ') * 2;
 		}
 
@@ -355,14 +360,14 @@ public class AWTChartToolkit {
 					} else {
 						label = formatter.format(currentTick);
 					}
-					ctx.drawLine(tickPos + 180, axisPos - TICK_LINE, tickPos + 180, axisPos + TICK_LINE);
+					ctx.drawLine(tickPos + xOffset, axisPos - TICK_LINE, tickPos + xOffset, axisPos + TICK_LINE);
 					int textXadjust = fm.stringWidth(label) / 2;
 					// FIXME: Decide if truncated labels should be shown
 //					if ((tickPos + textXadjust) >= axisSize) {
 					if (tickPos >= axisSize) {
 						break;
 					} else if ((tickPos - textXadjust) >= labelLimit) {
-						ctx.drawString(label, tickPos - textXadjust + 180, labelYPos);
+						ctx.drawString(label, tickPos - textXadjust + xOffset, labelYPos);
 						labelLimit = tickPos + textXadjust + labelSpacing;
 						lastShownTick = currentTick;
 					}

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/ChartFilterControlBar.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/ChartFilterControlBar.java
@@ -10,6 +10,7 @@ import org.eclipse.swt.widgets.Listener;
 
 import org.openjdk.jmc.common.unit.IQuantity;
 import org.openjdk.jmc.common.unit.IRange;
+import org.openjdk.jmc.ui.common.PatternFly.Palette;
 import org.openjdk.jmc.ui.misc.ChartCanvas;
 
 public class ChartFilterControlBar extends Composite {

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/TimeDisplay.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/TimeDisplay.java
@@ -8,7 +8,6 @@ import java.util.regex.Pattern;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.ModifyEvent;
 import org.eclipse.swt.events.ModifyListener;
-import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Text;
@@ -31,7 +30,6 @@ public class TimeDisplay extends Composite {
 			super(parent, SWT.NO_BACKGROUND);
 			this.setLayout(new GridLayout());
 			timeText = new Text(this, SWT.SEARCH | SWT.SINGLE);
-			timeText.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, false));
 			timeText.setTextLimit(12);
 			timeText.addModifyListener(new ModifyListener() {
 				@Override

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/TimeFilter.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/TimeFilter.java
@@ -38,7 +38,7 @@ public class TimeFilter extends Composite {
 	public TimeFilter(Composite parent, IRange<IQuantity> recordingRange, Listener resetListener) {
 		super(parent, SWT.NO_BACKGROUND);
 		this.setLayout(new GridLayout(7, false));
-		Label eventsLabel = new Label(this, SWT.LEFT | SWT.HORIZONTAL);
+		Label eventsLabel = new Label(this, SWT.LEFT);
 		eventsLabel.setText(FILTER_EVENTS);
 		eventsLabel.setFont(JFaceResources.getFontRegistry().get(JFaceResources.BANNER_FONT));
 

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/TimelineCanvas.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/TimelineCanvas.java
@@ -3,6 +3,7 @@ package org.openjdk.jmc.ui.charts;
 import java.awt.Graphics2D;
 
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.SashForm;
 import org.eclipse.swt.events.PaintEvent;
 import org.eclipse.swt.events.PaintListener;
 import org.eclipse.swt.graphics.Rectangle;
@@ -14,25 +15,29 @@ import org.openjdk.jmc.ui.misc.AwtCanvas;
 public class TimelineCanvas extends Canvas {
 	private static final int RANGE_INDICATOR_HEIGHT = 7;
 	private static final int RANGE_INDICATOR_Y_OFFSET = 30;
-	private final int xOffset;
+	private int xOffset;
 	private AwtCanvas awtCanvas;
 	private Graphics2D g2d;
 	private int x1;
 	private int x2;
-	private int axisWidth;
+	private SashForm sashForm;
 	private SubdividedQuantityRange xTickRange;
 
-	public TimelineCanvas(Composite parent, int xOffset) {
+	public TimelineCanvas(Composite parent, SashForm sash) {
 		super (parent, SWT.NONE);
-		this.xOffset = xOffset + 9;
+		sashForm = sash;
+		xOffset = calculateXOffset();
 		awtCanvas = new AwtCanvas();
 		addPaintListener(new TimelineCanvasPainter());
 	}
 
-	public void renderRangeIndicator(int x1, int x2, int axisWidth) {
+	private int calculateXOffset() {
+		return sashForm.getChildren()[0].getSize().x + sashForm.getSashWidth();
+	}
+
+	public void renderRangeIndicator(int x1, int x2) {
 		this.x1 = x1;
 		this.x2 = x2;
-		this.axisWidth = axisWidth;
 		this.redraw();
 	}
 
@@ -45,6 +50,8 @@ public class TimelineCanvas extends Canvas {
 
 		@Override
 		public void paintControl(PaintEvent e) {
+			xOffset = calculateXOffset();
+
 			Rectangle rect = getClientArea();
 			g2d = awtCanvas.getGraphics(rect.width, rect.height);
 
@@ -55,15 +62,14 @@ public class TimelineCanvas extends Canvas {
 			// Draw the horizontal axis
 			if (xTickRange != null) {
 				g2d.setColor(Palette.PF_BLACK.getAWTColor());
-				AWTChartToolkit.drawAxis(g2d, xTickRange, 0, false, 1 - xOffset, false);
+				AWTChartToolkit.drawAxis(g2d, xTickRange, 0, false, 1, false, xOffset);
 			}
 
 			// Draw the range indicator
 			g2d.setPaint(Palette.PF_ORANGE_400.getAWTColor());
 			g2d.fillRect(x1 + xOffset, RANGE_INDICATOR_Y_OFFSET, x2 - x1, RANGE_INDICATOR_HEIGHT);
 			g2d.setPaint(Palette.PF_BLACK_600.getAWTColor());
-			g2d.drawRect(xOffset, RANGE_INDICATOR_Y_OFFSET, axisWidth, RANGE_INDICATOR_HEIGHT);
-
+			g2d.drawRect(xOffset, RANGE_INDICATOR_Y_OFFSET, sashForm.getChildren()[1].getSize().x, RANGE_INDICATOR_HEIGHT);
 			awtCanvas.paint(e, 0, 0);
 		}
 	}

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/XYChart.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/XYChart.java
@@ -44,7 +44,6 @@ import java.util.Set;
 import java.util.Stack;
 import java.util.function.Consumer;
 
-import org.eclipse.swt.widgets.Scale;
 import org.openjdk.jmc.common.IDisplayable;
 import org.openjdk.jmc.common.unit.IQuantity;
 import org.openjdk.jmc.common.unit.IRange;
@@ -190,7 +189,7 @@ public class XYChart {
 		int x2 = (int) Math.ceil(fullRangeAxis.getPixel(currentEnd));
 		
 		if (timelineCanvas != null) {
-			timelineCanvas.renderRangeIndicator(x1, x2, axisWidth);
+			timelineCanvas.renderRangeIndicator(x1, x2);
 		} else {
 			context.setPaint(RANGE_INDICATION_COLOR);
 			context.fillRect(x1, rangeIndicatorY, x2 - x1, RANGE_INDICATOR_HEIGHT);
@@ -563,7 +562,7 @@ public class XYChart {
 	}
 
 	public void setVisibleRange(IQuantity rangeStart, IQuantity rangeEnd) {
-		if (rangeDuration != null && !isZoomCalculated && rangeStart != start && !isZoomPanDrag) {
+		if (rangeDuration != null && !isZoomCalculated && rangeStart != start && !getIsZoomPanDrag()) {
 			selectionZoom(rangeStart, rangeEnd);
 		}
 		isZoomCalculated = false;


### PR DESCRIPTION
This patch utilizes the sash form similar to the existing `ChartAndTableUI` mechanics.

The trickier part here was how moving the sash would impact the timeline canvas. Originally the timeline canvas was drawn at an offset equal to a fixed value, which would allow it to be drawn at the base of the chart. The approach this time is to draw the timeline elements at an offset equal to the text canvas (`sashForm.getChildren()[0]`) plus the width of the sash itself. When a paint event is triggered the timeline canvas can lookup the current sizing of the sashform elements and incorporate that value as the new `xOffset`.

Here is what it looks like in practice:
![2019-10-03-sashform](https://user-images.githubusercontent.com/10425301/66139407-601c4580-e5ce-11e9-9160-036c24f081e9.gif)

As an added bonus, this PR would directly address JMC-6366 [[0]](https://bugs.openjdk.java.net/browse/JMC-6366), which has to do with making the label area of the chart area resizeable.

[0] https://bugs.openjdk.java.net/browse/JMC-6366