### PR TITLE
Fix chart rendering issues

### DIFF
--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/ChartDisplayControlBar.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/ChartDisplayControlBar.java
@@ -407,8 +407,8 @@ public class ChartDisplayControlBar extends Composite {
 
 			int xOld = zoomRect.x;
 			zoomRect.x += xdiff;
-			if (zoomRect.x > (bounds.x - zoomRect.width - BORDER_PADDING))  {
-				zoomRect.x = bounds.x - zoomRect.width - BORDER_PADDING;
+			if (zoomRect.x > (bounds.x - zoomRect.width - BORDER_PADDING - 1))  {
+				zoomRect.x = bounds.x - zoomRect.width - BORDER_PADDING - 1;
 			} else if (zoomRect.x < BORDER_PADDING ) {
 				zoomRect.x = BORDER_PADDING;
 			}
@@ -418,8 +418,8 @@ public class ChartDisplayControlBar extends Composite {
 			zoomRect.y += ydiff;
 			if (zoomRect.y < BORDER_PADDING ) {
 				zoomRect.y = BORDER_PADDING;
-			} else if (zoomRect.y > (bounds.y - zoomRect.height - BORDER_PADDING))  {
-				zoomRect.y = bounds.y - zoomRect.height - BORDER_PADDING;
+			} else if (zoomRect.y > (bounds.y - zoomRect.height- BORDER_PADDING - 1))  {
+				zoomRect.y = bounds.y - zoomRect.height - BORDER_PADDING - 1;
 			}
 			yModified = yOld != zoomRect.y;
 
@@ -438,7 +438,7 @@ public class ChartDisplayControlBar extends Composite {
 						zoomCanvasBounds.x, zoomCanvasBounds.width - BORDER_PADDING);
 				int start = getPixelLocation(ratio, totalBounds.width, 0);
 
-				ratio = getVisibilityRatio(zoomRect.x + zoomRect.width + BORDER_PADDING,
+				ratio = getVisibilityRatio(zoomRect.x + zoomRect.width + BORDER_PADDING + 1,
 						zoomCanvasBounds.width, zoomCanvasBounds.width - BORDER_PADDING);
 				int end = getPixelLocation(ratio, totalBounds.width, totalBounds.width);
 
@@ -448,7 +448,8 @@ public class ChartDisplayControlBar extends Composite {
 				lastChartZoomedRange = chart.getVisibleRange();
 			}
 			if (updateYRange) {
-				double ratio = getVisibilityRatio(zoomRect.y - BORDER_PADDING, 0, zoomCanvasBounds.height);
+				double ratio = getVisibilityRatio(zoomRect.y - BORDER_PADDING, 0,
+						zoomCanvasBounds.height - BORDER_PADDING);
 				int top = getPixelLocation(ratio, totalBounds.height, 0);
 
 				Point p = ((ScrolledComposite) chartCanvas.getParent()).getOrigin();
@@ -469,7 +470,7 @@ public class ChartDisplayControlBar extends Composite {
 				gc.setBackground(Palette.PF_BLACK_400.getSWTColor());
 				gc.fillRectangle(backgroundRect);
 				gc.setForeground(Palette.PF_BLACK_900.getSWTColor());
-				gc.drawRectangle(backgroundRect);
+				gc.drawRectangle(0, 0, backgroundRect.width - 1 , backgroundRect.height - 1);
 
 				updateZoomRectFromChart();
 
@@ -498,7 +499,7 @@ public class ChartDisplayControlBar extends Composite {
 				int end = getPixelLocation(ratio, zoomCanvasBounds.width, zoomCanvasBounds.width);
 
 				zoomRect.x = start + BORDER_PADDING;
-				zoomRect.width = end - start - 2 * BORDER_PADDING;
+				zoomRect.width = end - start - 2 * BORDER_PADDING - 1;
 				lastChartZoomedRange = chart.getVisibleRange();
 			}
 			double ratio = getVisibilityRatio(0, totalBounds.y, totalBounds.height);
@@ -508,7 +509,7 @@ public class ChartDisplayControlBar extends Composite {
 			int bottom = getPixelLocation(ratio, zoomCanvasBounds.height, zoomCanvasBounds.height);
 
 			zoomRect.y  = top + BORDER_PADDING;
-			zoomRect.height = bottom - top - 2 * BORDER_PADDING;
+			zoomRect.height = bottom - top - 2 * BORDER_PADDING - 1;
 
 		}
 

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/TimelineCanvas.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/TimelineCanvas.java
@@ -6,15 +6,20 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.SashForm;
 import org.eclipse.swt.events.PaintEvent;
 import org.eclipse.swt.events.PaintListener;
+import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Canvas;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
 import org.openjdk.jmc.ui.common.PatternFly.Palette;
+import org.openjdk.jmc.ui.common.util.Environment;
 import org.openjdk.jmc.ui.misc.AwtCanvas;
 
 public class TimelineCanvas extends Canvas {
 	private static final int RANGE_INDICATOR_HEIGHT = 7;
 	private static final int RANGE_INDICATOR_Y_OFFSET = 30;
+	private final double xScale = Display.getDefault().getDPI().x / Environment.getNormalDPI();
+	private final double yScale = Display.getDefault().getDPI().y / Environment.getNormalDPI();
 	private int xOffset;
 	private AwtCanvas awtCanvas;
 	private Graphics2D g2d;
@@ -56,8 +61,9 @@ public class TimelineCanvas extends Canvas {
 			g2d = awtCanvas.getGraphics(rect.width, rect.height);
 
 			// Draw the background
+			Point adjusted = translateDisplayToImageCoordinates(rect.width, rect.height);
 			g2d.setColor(Palette.PF_BLACK_100.getAWTColor());
-			g2d.fillRect(0, 0, rect.width, rect.height);
+			g2d.fillRect(0, 0, adjusted.x, adjusted.y);
 
 			// Draw the horizontal axis
 			if (xTickRange != null) {
@@ -69,9 +75,17 @@ public class TimelineCanvas extends Canvas {
 			g2d.setPaint(Palette.PF_ORANGE_400.getAWTColor());
 			g2d.fillRect(x1 + xOffset, RANGE_INDICATOR_Y_OFFSET, x2 - x1, RANGE_INDICATOR_HEIGHT);
 			g2d.setPaint(Palette.PF_BLACK_600.getAWTColor());
-			g2d.drawRect(xOffset, RANGE_INDICATOR_Y_OFFSET, sashForm.getChildren()[1].getSize().x, RANGE_INDICATOR_HEIGHT);
+			Point totalSize = sashForm.getChildren()[1].getSize();
+			adjusted = translateDisplayToImageCoordinates(totalSize.x,totalSize.y);
+			g2d.drawRect(xOffset, RANGE_INDICATOR_Y_OFFSET, adjusted.x, RANGE_INDICATOR_HEIGHT);
 			awtCanvas.paint(e, 0, 0);
 		}
+	}
+
+	private Point translateDisplayToImageCoordinates(int x, int y) {
+		int xImage = (int) Math.round(x / xScale);
+		int yImage = (int) Math.round(y / yScale);
+		return new Point(xImage, yImage);
 	}
 
 }

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartCanvas.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartCanvas.java
@@ -235,12 +235,12 @@ public class ChartCanvas extends Canvas {
 
 			if (awtNeedsRedraw || !awtCanvas.hasImage(rect.width, rect.height)) {
 				Graphics2D g2d = awtCanvas.getGraphics(rect.width, rect.height);
-				g2d.setColor(Palette.PF_BLACK_100.getAWTColor());
-				g2d.fillRect(0, 0, rect.width, rect.height);
 				Point adjusted = translateDisplayToImageCoordinates(rect.width, rect.height);
+				g2d.setColor(Palette.PF_BLACK_100.getAWTColor());
+				g2d.fillRect(0, 0, adjusted.x, adjusted.y);
 				render(g2d, adjusted.x, adjusted.y);
 				if (getParent() instanceof ScrolledComposite) {
-					((ScrolledComposite) getParent()).setMinSize(adjusted.x, adjusted.y);
+					((ScrolledComposite) getParent()).setMinSize(rect.width, rect.height);
 				}
 				if (highlightRects != null) {
 					updateHighlightRects();

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartTextCanvas.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartTextCanvas.java
@@ -228,12 +228,12 @@ public class ChartTextCanvas extends Canvas {
 
 			if (awtNeedsRedraw || !awtCanvas.hasImage(rect.width, rect.height)) {
 				Graphics2D g2d = awtCanvas.getGraphics(rect.width, rect.height);
-				g2d.setColor(Palette.PF_BLACK_100.getAWTColor());
-				g2d.fillRect(0, 0, rect.width, rect.height);
 				Point adjusted = translateDisplayToImageCoordinates(rect.width, rect.height);
+				g2d.setColor(Palette.PF_BLACK_100.getAWTColor());
+				g2d.fillRect(0, 0, adjusted.x, adjusted.y);
 				render(g2d, adjusted.x, adjusted.y);
 				if (getParent() instanceof ScrolledComposite) {
-					((ScrolledComposite) getParent()).setMinSize(adjusted.x, adjusted.y);
+					((ScrolledComposite) getParent()).setMinSize(rect.width, rect.height);
 				}
 				if (highlightRects != null) {
 					updateHighlightRects();


### PR DESCRIPTION
This patch addresses the following rendering issues:
1. Make the zoom-pan display render with a full border
2. Make the chart canvas and other related canvases render with bounds according to image coordinates instead of display ones.  Before this fix black areas were visible in areas where a canvas did not cover:
![before](https://user-images.githubusercontent.com/29706926/66155395-89000300-e5ed-11e9-8168-50f5bc14bbd7.png)

After fix:
![after](https://user-images.githubusercontent.com/29706926/66155396-89000300-e5ed-11e9-984d-d8a91791a8dc.png)