### PR TITLE
Prevent lane with thread activity from highlighting on zoom click

### DIFF
--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartCanvas.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartCanvas.java
@@ -624,8 +624,8 @@ public class ChartCanvas extends Canvas {
 				if (!awtChart.select(p.x, p.x, p.y, p.y, true)) {
 					awtChart.clearSelection();
 				}
-				notifyZoomOnClickListener(SWT.MouseDown);
 			}
+			notifyZoomOnClickListener(SWT.MouseDown);
 			redrawChart();
 			redrawChartText();
 		}


### PR DESCRIPTION
This patch prevents a lane with thread activity from being highlighted when a user clicks on it in order to zoom in/out the chart.