### PR TITLE
Fix thread selection through shift+click on text canvas

### DIFF
--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartTextCanvas.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartTextCanvas.java
@@ -146,7 +146,7 @@ public class ChartTextCanvas extends Canvas {
 						lastSelection = highlightSelectionEnd;
 					}
 				}
-				select(highlightSelectionStart.x, highlightSelectionEnd.x, highlightSelectionStart.y, highlightSelectionEnd.y, true);
+				select(highlightSelectionStart.x, highlightSelectionStart.x, highlightSelectionStart.y, highlightSelectionEnd.y, true);
 				if (selectionListener != null) {
 					selectionListener.run();
 				}


### PR DESCRIPTION
This patch makes it possible for the user to select multiple threads in their entirety through shift+click on the text canvas. 