### PR TITLE
Make popup table selection all input on creation

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ThreadsPage.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ThreadsPage.java
@@ -45,11 +45,13 @@ import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.action.Separator;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.viewers.StructuredSelection;
+import org.eclipse.jface.viewers.TableViewer;
 import org.eclipse.jface.wizard.WizardPage;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Item;
 import org.eclipse.ui.forms.widgets.FormToolkit;
 import org.openjdk.jmc.common.IMCThread;
 import org.openjdk.jmc.common.IState;
@@ -397,19 +399,26 @@ public class ThreadsPage extends AbstractDataPage {
 						pageContainer.getSelectionStore()::getSelections, this::onFilterChangeHelper);
 				mm.add(tableFilterComponent.getShowFilterAction());
 				mm.add(tableFilterComponent.getShowSearchAction());
-
 				table.getManager().setSelectionState(histogramSelectionState);
 				tableFilterComponent.loadState(state.getChild(THREADS_TABLE_FILTER));
 				onFilterChange(tableFilter);
 
 				if (selectionInput != null) {
 					table.getManager().getViewer().setSelection(new StructuredSelection(selectionInput));
-				} else {
-					table.getManager().getViewer().setSelection(
-							new StructuredSelection((Object[]) table.getManager().getViewer().getInput()));
+				}
+
+				Item[] columnWidgets = ((TableViewer) table.getManager().getViewer()).getTable().getColumns();
+				for (Item columWidget : columnWidgets) {
+					columWidget.addListener(SWT.Selection, e -> columnSortChanged());
 				}
 
 				setControl(parent);
+			}
+
+			private void columnSortChanged() {
+				if (!table.getSelection().getItems().hasItems()) {
+					buildChart();
+				}
 			}
 
 			private void onFilterChangeHelper(IItemFilter filter) {

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ThreadsPage.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ThreadsPage.java
@@ -404,6 +404,9 @@ public class ThreadsPage extends AbstractDataPage {
 
 				if (selectionInput != null) {
 					table.getManager().getViewer().setSelection(new StructuredSelection(selectionInput));
+				} else {
+					table.getManager().getViewer().setSelection(
+							new StructuredSelection((Object[]) table.getManager().getViewer().getInput()));
 				}
 
 				setControl(parent);


### PR DESCRIPTION
On popup table creation this patch sets the table's selected items to be all table input.  This default selection is kept until the user chooses another selection. This enables the chart to respond to actions in the table, such as sorting by column, when no selection has been specified by the user. 