### PR TITLE
remove duplicate display translation functions and cleanup unused imports

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/META-INF/MANIFEST.MF
+++ b/application/org.openjdk.jmc.flightrecorder.ui/META-INF/MANIFEST.MF
@@ -22,4 +22,3 @@ Export-Package: org.openjdk.jmc.flightrecorder.ui,
  org.openjdk.jmc.flightrecorder.ui.preferences,
  org.openjdk.jmc.flightrecorder.ui.selection
 Automatic-Module-Name: org.openjdk.jmc.flightrecorder.ui
-Import-Package: org.eclipse.jdt.core.dom

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/TypeLabelProvider.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/TypeLabelProvider.java
@@ -36,7 +36,6 @@ import java.awt.Color;
 
 import org.openjdk.jmc.common.util.ColorToolkit;
 import org.openjdk.jmc.flightrecorder.jdk.JdkTypeIDs;
-import org.openjdk.jmc.ui.common.PatternFly.Palette;
 
 // May evolve into a label provider
 public class TypeLabelProvider {

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ChartAndPopupTableUI.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ChartAndPopupTableUI.java
@@ -79,7 +79,6 @@ import org.openjdk.jmc.ui.charts.ChartFilterControlBar;
 import org.openjdk.jmc.ui.charts.IXDataRenderer;
 import org.openjdk.jmc.ui.charts.RendererToolkit;
 import org.openjdk.jmc.ui.charts.XYChart;
-import org.openjdk.jmc.ui.common.PatternFly.Palette;
 import org.openjdk.jmc.ui.handlers.ActionToolkit;
 import org.openjdk.jmc.ui.misc.ActionUiToolkit;
 import org.openjdk.jmc.ui.misc.ChartCanvas;
@@ -87,6 +86,7 @@ import org.openjdk.jmc.ui.misc.ChartDisplayControlBar;
 import org.openjdk.jmc.ui.misc.ChartTextCanvas;
 import org.openjdk.jmc.ui.misc.PersistableSashForm;
 import org.openjdk.jmc.ui.misc.TimelineCanvas;
+import org.openjdk.jmc.ui.misc.PatternFly.Palette;
 
 abstract class ChartAndPopupTableUI implements IPageUI {
 

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ChartAndPopupTableUI.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ChartAndPopupTableUI.java
@@ -75,18 +75,18 @@ import org.openjdk.jmc.flightrecorder.ui.common.ItemHistogram;
 import org.openjdk.jmc.flightrecorder.ui.common.ItemHistogram.HistogramSelection;
 import org.openjdk.jmc.flightrecorder.ui.messages.internal.Messages;
 import org.openjdk.jmc.flightrecorder.ui.selection.SelectionStoreActionToolkit;
-import org.openjdk.jmc.ui.charts.ChartDisplayControlBar;
 import org.openjdk.jmc.ui.charts.ChartFilterControlBar;
 import org.openjdk.jmc.ui.charts.IXDataRenderer;
 import org.openjdk.jmc.ui.charts.RendererToolkit;
-import org.openjdk.jmc.ui.charts.TimelineCanvas;
 import org.openjdk.jmc.ui.charts.XYChart;
 import org.openjdk.jmc.ui.common.PatternFly.Palette;
 import org.openjdk.jmc.ui.handlers.ActionToolkit;
 import org.openjdk.jmc.ui.misc.ActionUiToolkit;
 import org.openjdk.jmc.ui.misc.ChartCanvas;
+import org.openjdk.jmc.ui.misc.ChartDisplayControlBar;
 import org.openjdk.jmc.ui.misc.ChartTextCanvas;
 import org.openjdk.jmc.ui.misc.PersistableSashForm;
+import org.openjdk.jmc.ui.misc.TimelineCanvas;
 
 abstract class ChartAndPopupTableUI implements IPageUI {
 

--- a/application/org.openjdk.jmc.ui.common/META-INF/MANIFEST.MF
+++ b/application/org.openjdk.jmc.ui.common/META-INF/MANIFEST.MF
@@ -9,9 +9,6 @@ Bundle-Vendor: Oracle Corporation
 Require-Bundle: org.eclipse.core.runtime;visibility:=reexport,
  org.openjdk.jmc.common;visibility:=reexport
 Bundle-ActivationPolicy: lazy
-Import-Package: org.eclipse.core.expressions,
- org.eclipse.swt.graphics,
- org.eclipse.swt.widgets
 Export-Package: org.openjdk.jmc.ui.common,
  org.openjdk.jmc.ui.common.action,
  org.openjdk.jmc.ui.common.idesupport,

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/ChartFilterControlBar.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/ChartFilterControlBar.java
@@ -10,8 +10,8 @@ import org.eclipse.swt.widgets.Listener;
 
 import org.openjdk.jmc.common.unit.IQuantity;
 import org.openjdk.jmc.common.unit.IRange;
-import org.openjdk.jmc.ui.common.PatternFly.Palette;
 import org.openjdk.jmc.ui.misc.ChartCanvas;
+import org.openjdk.jmc.ui.misc.PatternFly.Palette;
 
 public class ChartFilterControlBar extends Composite {
 

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/RenderedRowBase.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/RenderedRowBase.java
@@ -89,4 +89,5 @@ public class RenderedRowBase implements IRenderedRow {
 	public void infoAt(IChartInfoVisitor visitor, int x, int y, Point offset) {
 
 	}
+
 }

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/SpanRenderer.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/SpanRenderer.java
@@ -82,7 +82,6 @@ public class SpanRenderer<T> implements IXDataRenderer {
 		private final ISpanSeries<T> series;
 		private final XYQuantities<T[]> points;
 		private String description;
-		private Object data;
 
 		SpanRendering(int height, XYQuantities<T[]> quantities, ISpanSeries<T> series,
 				IColorProvider<? super T> colorProvider, String description) {
@@ -91,13 +90,10 @@ public class SpanRenderer<T> implements IXDataRenderer {
 			this.series = series;
 			this.colorProvider = colorProvider;
 			this.description = description;
-			this.data = null;
 		}
 
 		@Override
 		public void infoAt(IChartInfoVisitor visitor, int x, int y, Point offset) {
-			visitor.hover(data);
-			
 			if (points != null) {
 				int bucket = points.floorIndexAtX(x);
 				if (bucket >= 0 && bucket < points.getSize()) {

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/TimeDisplay.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/TimeDisplay.java
@@ -13,7 +13,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Text;
 import org.openjdk.jmc.common.unit.IQuantity;
 import org.openjdk.jmc.common.unit.UnitLookup;
-import org.openjdk.jmc.ui.common.PatternFly.Palette;
+import org.openjdk.jmc.ui.misc.PatternFly.Palette;
 
 public class TimeDisplay extends Composite {
 

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/XYChart.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/XYChart.java
@@ -52,6 +52,8 @@ import org.openjdk.jmc.common.unit.QuantityRange;
 import org.openjdk.jmc.common.unit.UnitLookup;
 import org.openjdk.jmc.ui.charts.IChartInfoVisitor.ITick;
 import org.openjdk.jmc.ui.common.PatternFly.Palette;
+import org.openjdk.jmc.ui.misc.ChartDisplayControlBar;
+import org.openjdk.jmc.ui.misc.TimelineCanvas;
 
 public class XYChart {
 	private static final String ELLIPSIS = "..."; //$NON-NLS-1$

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/XYChart.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/XYChart.java
@@ -51,9 +51,9 @@ import org.openjdk.jmc.common.unit.QuantitiesToolkit;
 import org.openjdk.jmc.common.unit.QuantityRange;
 import org.openjdk.jmc.common.unit.UnitLookup;
 import org.openjdk.jmc.ui.charts.IChartInfoVisitor.ITick;
-import org.openjdk.jmc.ui.common.PatternFly.Palette;
 import org.openjdk.jmc.ui.misc.ChartDisplayControlBar;
 import org.openjdk.jmc.ui.misc.TimelineCanvas;
+import org.openjdk.jmc.ui.misc.PatternFly.Palette;
 
 public class XYChart {
 	private static final String ELLIPSIS = "..."; //$NON-NLS-1$

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartCanvas.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartCanvas.java
@@ -468,7 +468,7 @@ public class ChartCanvas extends Canvas {
 	 *            the provided y coordinate
 	 * @return a Point that represents the (x,y) coordinates in the chart's coordinate space
 	 */
-	private Point translateDisplayToImageCoordinates(int x, int y) {
+	protected Point translateDisplayToImageCoordinates(int x, int y) {
 		int xImage = (int) Math.round(x / xScale);
 		int yImage = (int) Math.round(y / yScale);
 		return new Point(xImage, yImage);
@@ -481,8 +481,19 @@ public class ChartCanvas extends Canvas {
 	 *            the provided display x coordinate
 	 * @return the x coordinate in the chart's coordinate space
 	 */
-	private int translateDisplayToImageXCoordinates(int x) {
+	protected int translateDisplayToImageXCoordinates(int x) {
 		return (int) Math.round(x / xScale);
+	}
+
+	/**
+	 * Translates a display x coordinate into an image x coordinate for the chart.
+	 *
+	 * @param x
+	 *            the provided display x coordinate
+	 * @return the x coordinate in the chart's coordinate space
+	 */
+	protected int translateDisplayToImageYCoordinates(int y) {
+		return (int) Math.round(y / yScale);
 	}
 
 	public Object getHoveredItemData() {

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartCanvas.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartCanvas.java
@@ -71,10 +71,10 @@ import org.openjdk.jmc.ui.accessibility.FocusTracker;
 import org.openjdk.jmc.ui.charts.IChartInfoVisitor;
 import org.openjdk.jmc.ui.charts.IXDataRenderer;
 import org.openjdk.jmc.ui.charts.XYChart;
-import org.openjdk.jmc.ui.common.PatternFly.Palette;
 import org.openjdk.jmc.ui.common.util.Environment;
 import org.openjdk.jmc.ui.common.util.Environment.OSType;
 import org.openjdk.jmc.ui.handlers.MCContextMenuManager;
+import org.openjdk.jmc.ui.misc.PatternFly.Palette;
 
 public class ChartCanvas extends Canvas {
 	private static int MIN_LANE_HEIGHT = 50;

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartDisplayControlBar.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartDisplayControlBar.java
@@ -34,8 +34,8 @@ import org.openjdk.jmc.common.unit.IRange;
 import org.openjdk.jmc.ui.UIPlugin;
 import org.openjdk.jmc.ui.charts.SubdividedQuantityRange;
 import org.openjdk.jmc.ui.charts.XYChart;
-import org.openjdk.jmc.ui.common.PatternFly.Palette;
 import org.openjdk.jmc.ui.common.util.Environment;
+import org.openjdk.jmc.ui.misc.PatternFly.Palette;
 
 public class ChartDisplayControlBar extends Composite {
 	private static final String ZOOM_IN_CURSOR = "zoomInCursor";

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartDisplayControlBar.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartDisplayControlBar.java
@@ -105,15 +105,12 @@ public class ChartDisplayControlBar extends Composite {
 	public ChartDisplayControlBar(Composite parent) {
 		super(parent, SWT.NO_BACKGROUND);
 
-		GridLayout layout = new GridLayout();
-		layout.numColumns = 1;
-		layout.makeColumnsEqualWidth = false;
 		this.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, true));
 		this.setBackground(Display.getCurrent().getSystemColor(SWT.COLOR_GRAY));
-		this.setLayout(layout);
+		this.setLayout(new GridLayout());
 
-		cursors.put(DEFAULT_CURSOR, Display.getCurrent().getSystemCursor(SWT.CURSOR_ARROW));
-		cursors.put(HAND_CURSOR, Display.getCurrent().getSystemCursor(SWT.CURSOR_HAND));
+		cursors.put(DEFAULT_CURSOR, getDisplay().getSystemCursor(SWT.CURSOR_ARROW));
+		cursors.put(HAND_CURSOR, getDisplay().getSystemCursor(SWT.CURSOR_HAND));
 		cursors.put(ZOOM_IN_CURSOR, new Cursor(getDisplay(),
 				UIPlugin.getDefault().getImage(UIPlugin.ICON_FA_ZOOM_IN).getImageData(), 0, 0));
 		cursors.put(ZOOM_OUT_CURSOR, new Cursor(getDisplay(),
@@ -132,8 +129,6 @@ public class ChartDisplayControlBar extends Composite {
 			};
 		});
 		buttonGroup.add(selectionBtn);
-
-		// SPACE
 
 		zoomInBtn = new Button(this, SWT.TOGGLE);
 		zoomInBtn.setLayoutData(new GridData(SWT.CENTER, SWT.CENTER, false, false));
@@ -192,8 +187,6 @@ public class ChartDisplayControlBar extends Composite {
 		});
 		zoomOutBtn.addMouseListener(new LongPressListener(-ZOOM_AMOUNT));
 		buttonGroup.add(zoomOutBtn);
-
-		// SPACE
 
 		zoomPanBtn = new Button(this, SWT.TOGGLE);
 		zoomPanBtn.setLayoutData(new GridData(SWT.CENTER, SWT.CENTER, false, false));

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartDisplayControlBar.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartDisplayControlBar.java
@@ -1,4 +1,4 @@
-package org.openjdk.jmc.ui.charts;
+package org.openjdk.jmc.ui.misc;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -32,11 +32,10 @@ import org.eclipse.swt.widgets.Text;
 import org.openjdk.jmc.common.unit.IQuantity;
 import org.openjdk.jmc.common.unit.IRange;
 import org.openjdk.jmc.ui.UIPlugin;
+import org.openjdk.jmc.ui.charts.SubdividedQuantityRange;
+import org.openjdk.jmc.ui.charts.XYChart;
 import org.openjdk.jmc.ui.common.PatternFly.Palette;
 import org.openjdk.jmc.ui.common.util.Environment;
-import org.openjdk.jmc.ui.misc.ChartCanvas;
-import org.openjdk.jmc.ui.misc.ChartTextCanvas;
-import org.openjdk.jmc.ui.misc.DisplayToolkit;
 
 public class ChartDisplayControlBar extends Composite {
 	private static final String ZOOM_IN_CURSOR = "zoomInCursor";
@@ -341,9 +340,6 @@ public class ChartDisplayControlBar extends Composite {
 		private IRange<IQuantity> lastChartZoomedRange;
 		private Rectangle zoomRect;
 
-		private final double xScale = Display.getDefault().getDPI().x / Environment.getNormalDPI();
-		private final double yScale = Display.getDefault().getDPI().y / Environment.getNormalDPI();
-
 		public ZoomPan(Composite parent) {
 			super(parent, SWT.NO_BACKGROUND);
 			addPaintListener(new Painter());
@@ -368,7 +364,7 @@ public class ChartDisplayControlBar extends Composite {
 				if (e.button == 1 && zoomRect.contains(e.x, e.y)) {
 					isPan = true;
 					chart.setIsZoomPanDrag(isPan);
-					currentSelection = translateDisplayToImageCoordinates(e.x, e.y);
+					currentSelection = chartCanvas.translateDisplayToImageCoordinates(e.x, e.y);
 				}
 			}
 
@@ -383,7 +379,7 @@ public class ChartDisplayControlBar extends Composite {
 				zoomPan.setCursor(cursors.get(HAND_CURSOR));
 				if (isPan && getParent().getSize().x >= e.x && getParent().getSize().y >= e.y ) {
 					lastSelection = currentSelection;
-					currentSelection = translateDisplayToImageCoordinates(e.x, e.y);
+					currentSelection = chartCanvas.translateDisplayToImageCoordinates(e.x, e.y);
 					int xdiff = currentSelection.x - lastSelection.x;
 					int ydiff = currentSelection.y - lastSelection.y;
 					updateZoomRectFromPan(xdiff, ydiff);
@@ -394,12 +390,6 @@ public class ChartDisplayControlBar extends Composite {
 			public void mouseScrolled(MouseEvent e) {
 				updateZoomRectFromPan(0, -e.count);
 			}
-		}
-
-		private Point translateDisplayToImageCoordinates(int x, int y) {
-			int xImage = (int) Math.round(x / xScale);
-			int yImage = (int) Math.round(y / yScale);
-			return new Point(xImage, yImage);
 		}
 
 		private void updateZoomRectFromPan(int xdiff, int ydiff) {

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartTextCanvas.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartTextCanvas.java
@@ -64,9 +64,9 @@ import org.openjdk.jmc.ui.accessibility.FocusTracker;
 import org.openjdk.jmc.ui.charts.IChartInfoVisitor;
 import org.openjdk.jmc.ui.charts.IXDataRenderer;
 import org.openjdk.jmc.ui.charts.XYChart;
-import org.openjdk.jmc.ui.common.PatternFly.Palette;
 import org.openjdk.jmc.ui.common.util.Environment;
 import org.openjdk.jmc.ui.handlers.MCContextMenuManager;
+import org.openjdk.jmc.ui.misc.PatternFly.Palette;
 
 public class ChartTextCanvas extends Canvas {
 	private static int MIN_LANE_HEIGHT = 50;

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartTextCanvas.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartTextCanvas.java
@@ -228,7 +228,7 @@ public class ChartTextCanvas extends Canvas {
 
 			if (awtNeedsRedraw || !awtCanvas.hasImage(rect.width, rect.height)) {
 				Graphics2D g2d = awtCanvas.getGraphics(rect.width, rect.height);
-				Point adjusted = translateDisplayToImageCoordinates(rect.width, rect.height);
+				Point adjusted = chartCanvas.translateDisplayToImageCoordinates(rect.width, rect.height);
 				g2d.setColor(Palette.PF_BLACK_100.getAWTColor());
 				g2d.fillRect(0, 0, adjusted.x, adjusted.y);
 				render(g2d, adjusted.x, adjusted.y);
@@ -241,26 +241,6 @@ public class ChartTextCanvas extends Canvas {
 				awtNeedsRedraw = false;
 			}
 			awtCanvas.paint(e, 0, 0);
-			// Crude, flickering highlight of areas also delivered to tooltips.
-			// FIXME: Remove flicker by drawing in a buffered stage (AWT or SWT).
-//			List<Rectangle2D> rs = highlightRects;
-//			if (rs != null) {
-//				GC gc = e.gc;
-//				gc.setForeground(getForeground());
-//				for (Rectangle2D r : rs) {
-//					int x = (int) (((int) r.getX()) * xScale);
-//					int y = (int) (((int) r.getY()) * yScale);
-//					if ((r.getWidth() == 0) && (r.getHeight() == 0)) {
-//						int width = (int) Math.round(4 * xScale);
-//						int height = (int) Math.round(4 * yScale);
-//						gc.drawOval(x - (int) Math.round(2 * xScale), y - (int) Math.round(2 * yScale), width, height);
-//					} else {
-//						int width = (int) Math.round(r.getWidth() * xScale);
-//						int height = (int) Math.round(r.getHeight() * yScale);
-////						gc.drawRectangle(x, y, width, height);
-//					}
-//				}
-//			}
 		}
 	}
 
@@ -356,21 +336,6 @@ public class ChartTextCanvas extends Canvas {
 		}
 	}
 
-	/**
-	 * Translates display coordinates into image coordinates for the chart.
-	 *
-	 * @param x
-	 *            the provided x coordinate
-	 * @param y
-	 *            the provided y coordinate
-	 * @return a Point that represents the (x,y) coordinates in the chart's coordinate space
-	 */
-	private Point translateDisplayToImageCoordinates(int x, int y) {
-		int xImage = (int) Math.round(x / xScale);
-		int yImage = (int) Math.round(y / yScale);
-		return new Point(xImage, yImage);
-	}
-
 	public Object getHoveredItemData() {
 		return this.hoveredItemData;
 	}
@@ -453,35 +418,15 @@ public class ChartTextCanvas extends Canvas {
 	}
 
 	private void toggleSelect(int x, int y) {
-		Point p = translateDisplayToImageCoordinates(x, y);
+		Point p = chartCanvas.translateDisplayToImageCoordinates(x, y);
 		if (awtChart != null) {
 			final IQuantity[] range = new IQuantity[2];
-			infoAt(new IChartInfoVisitor.Adapter() {
-				@Override
-				public void visit(IBucket bucket) {
-//					if (range[0] == null) {
-//						range[0] = (IQuantity) bucket.getStartX();
-//						range[1] = (IQuantity) bucket.getEndX();
-//					}
-				}
-
-				@Override
-				public void visit(ISpan span) {
-//					if (range[0] == null) {
-//						IDisplayable x0 = span.getStartX();
-//						IDisplayable x1 = span.getEndX();
-//						range[0] = (x0 instanceof IQuantity) ? (IQuantity) x0 : null;
-//						range[1] = (x1 instanceof IQuantity) ? (IQuantity) x1 : null;
-//					}
-				}
-			}, x, y);
 			if ((range[0] != null) || (range[1] != null)) {
 				if (!awtChart.select(range[0], range[1], p.y, p.y, true)) {
 					awtChart.clearSelection();
 				}
 			} else {
 				if (!awtChart.select(p.x, p.x, p.y, p.y, true)) {
-					// range is [null, null]
 					awtChart.clearSelection();
 				}
 			}
@@ -523,7 +468,7 @@ public class ChartTextCanvas extends Canvas {
 	}
 
 	public void infoAt(IChartInfoVisitor visitor, int x, int y) {
-		Point p = translateDisplayToImageCoordinates(x, y);
+		Point p = chartCanvas.translateDisplayToImageCoordinates(x, y);
 		if (awtChart != null) {
 			awtChart.infoAt(visitor, p.x, p.y);
 		}

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/PatternFly.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/PatternFly.java
@@ -31,7 +31,7 @@
  * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
  * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.openjdk.jmc.ui.common;
+package org.openjdk.jmc.ui.misc;
 
 import org.eclipse.swt.widgets.Display;
 

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/TimelineCanvas.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/TimelineCanvas.java
@@ -20,7 +20,7 @@ import org.openjdk.jmc.common.unit.IRange;
 import org.openjdk.jmc.ui.charts.AWTChartToolkit;
 import org.openjdk.jmc.ui.charts.SubdividedQuantityRange;
 import org.openjdk.jmc.ui.charts.XYChart;
-import org.openjdk.jmc.ui.common.PatternFly.Palette;
+import org.openjdk.jmc.ui.misc.PatternFly.Palette;
 
 public class TimelineCanvas extends Canvas {
 	private static final int RANGE_INDICATOR_HEIGHT = 10;

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/TimelineCanvas.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/TimelineCanvas.java
@@ -13,7 +13,6 @@ import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Canvas;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Display;
 
 import org.openjdk.jmc.common.unit.IQuantity;
 import org.openjdk.jmc.common.unit.IRange;
@@ -136,9 +135,9 @@ public class TimelineCanvas extends Canvas {
 			e.x = chartCanvas.translateDisplayToImageXCoordinates(e.x);
 			e.y = chartCanvas.translateDisplayToImageYCoordinates(e.y);
 			if (timelineRect.contains(e.x, e.y)) {
-				setCursor(Display.getCurrent().getSystemCursor(SWT.CURSOR_HAND));
+				setCursor(getDisplay().getSystemCursor(SWT.CURSOR_HAND));
 			} else {
-				setCursor(Display.getCurrent().getSystemCursor(SWT.CURSOR_ARROW));
+				setCursor(getDisplay().getSystemCursor(SWT.CURSOR_ARROW));
 			}
 			if (isDrag) {
 				lastSelection = currentSelection;

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/TimelineCanvas.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/TimelineCanvas.java
@@ -1,4 +1,4 @@
-package org.openjdk.jmc.ui.charts;
+package org.openjdk.jmc.ui.misc;
 
 import java.awt.Graphics2D;
 
@@ -17,14 +17,12 @@ import org.eclipse.swt.widgets.Display;
 
 import org.openjdk.jmc.common.unit.IQuantity;
 import org.openjdk.jmc.common.unit.IRange;
+import org.openjdk.jmc.ui.charts.AWTChartToolkit;
+import org.openjdk.jmc.ui.charts.SubdividedQuantityRange;
+import org.openjdk.jmc.ui.charts.XYChart;
 import org.openjdk.jmc.ui.common.PatternFly.Palette;
-import org.openjdk.jmc.ui.common.util.Environment;
-import org.openjdk.jmc.ui.misc.AwtCanvas;
-import org.openjdk.jmc.ui.misc.ChartCanvas;
 
 public class TimelineCanvas extends Canvas {
-	private final double xScale = Display.getDefault().getDPI().x / Environment.getNormalDPI();
-	private final double yScale = Display.getDefault().getDPI().y / Environment.getNormalDPI();
 	private static final int RANGE_INDICATOR_HEIGHT = 10;
 	private static final int RANGE_INDICATOR_Y_OFFSET = 25;
 	private int x1;
@@ -75,13 +73,13 @@ public class TimelineCanvas extends Canvas {
 
 		@Override
 		public void paintControl(PaintEvent e) {
-			xOffset = translateDisplayToImageXCoordinates(calculateXOffset());
+			xOffset = chartCanvas.translateDisplayToImageXCoordinates(calculateXOffset());
 
 			Rectangle rect = getClientArea();
 			g2d = awtCanvas.getGraphics(rect.width, rect.height);
 
 			// Draw the background
-			Point adjusted = translateDisplayToImageCoordinates(rect.width, rect.height);
+			Point adjusted = chartCanvas.translateDisplayToImageCoordinates(rect.width, rect.height);
 			g2d.setColor(Palette.PF_BLACK_100.getAWTColor());
 			g2d.fillRect(0, 0, adjusted.x, adjusted.y);
 
@@ -93,59 +91,22 @@ public class TimelineCanvas extends Canvas {
 
 			// Draw the range indicator
 			indicatorRect = dragRect != null ? dragRect : new Rectangle(
-					x1 + xOffset, translateDisplayToImageYCoordinates(RANGE_INDICATOR_Y_OFFSET),
-					x2 - x1, translateDisplayToImageYCoordinates(RANGE_INDICATOR_HEIGHT));
+					x1 + xOffset, chartCanvas.translateDisplayToImageYCoordinates(RANGE_INDICATOR_Y_OFFSET),
+					x2 - x1, chartCanvas.translateDisplayToImageYCoordinates(RANGE_INDICATOR_HEIGHT));
 			dragRect = null;
 			g2d.setPaint(Palette.PF_ORANGE_400.getAWTColor());
 			g2d.fillRect(indicatorRect.x, indicatorRect.y, indicatorRect.width, indicatorRect.height);
 
 			Point totalSize = sashForm.getChildren()[1].getSize();
-			adjusted = translateDisplayToImageCoordinates(totalSize.x, totalSize.y);
+			adjusted = chartCanvas.translateDisplayToImageCoordinates(totalSize.x, totalSize.y);
 			timelineRect = new Rectangle(
-					xOffset, translateDisplayToImageYCoordinates(RANGE_INDICATOR_Y_OFFSET),
-					adjusted.x, translateDisplayToImageYCoordinates(RANGE_INDICATOR_HEIGHT));
+					xOffset, chartCanvas.translateDisplayToImageYCoordinates(RANGE_INDICATOR_Y_OFFSET),
+					adjusted.x, chartCanvas.translateDisplayToImageYCoordinates(RANGE_INDICATOR_HEIGHT));
 			g2d.setPaint(Palette.PF_BLACK_600.getAWTColor());
 			g2d.drawRect(timelineRect.x, timelineRect.y, timelineRect.width, timelineRect.height);
 
 			awtCanvas.paint(e, 0, 0);
 		}
-	}
-
-	/**
-	 * Translates display coordinates into image coordinates for the chart.
-	 *
-	 * @param x
-	 *            the provided x coordinate
-	 * @param y
-	 *            the provided y coordinate
-	 * @return a Point that represents the (x,y) coordinates in the chart's coordinate space
-	 */
-	private Point translateDisplayToImageCoordinates(int x, int y) {
-		int xImage = (int) Math.round(x / xScale);
-		int yImage = (int) Math.round(y / yScale);
-		return new Point(xImage, yImage);
-	}
-
-	/**
-	 * Translates a display x coordinate into an image x coordinate for the chart.
-	 *
-	 * @param x
-	 *            the provided display x coordinate
-	 * @return the x coordinate in the chart's coordinate space
-	 */
-	private int translateDisplayToImageXCoordinates(int x) {
-		return (int) Math.round(x / xScale);
-	}
-
-	/**
-	 * Translates a display x coordinate into an image x coordinate for the chart.
-	 *
-	 * @param x
-	 *            the provided display x coordinate
-	 * @return the x coordinate in the chart's coordinate space
-	 */
-	private int translateDisplayToImageYCoordinates(int y) {
-		return (int) Math.round(y / yScale);
 	}
 
 	private class DragDetector extends MouseAdapter implements MouseMoveListener {
@@ -156,8 +117,8 @@ public class TimelineCanvas extends Canvas {
 
 		@Override
 		public void mouseDown(MouseEvent e) {
-			e.x = translateDisplayToImageXCoordinates(e.x);
-			e.y = translateDisplayToImageYCoordinates(e.y);
+			e.x = chartCanvas.translateDisplayToImageXCoordinates(e.x);
+			e.y = chartCanvas.translateDisplayToImageYCoordinates(e.y);
 			if (isDrag || e.button == 1 && timelineRect.contains(e.x, e.y)) {
 				isDrag = true;
 				currentSelection = new Point(e.x, e.y);
@@ -172,8 +133,8 @@ public class TimelineCanvas extends Canvas {
 
 		@Override
 		public void mouseMove(MouseEvent e) {
-			e.x = translateDisplayToImageXCoordinates(e.x);
-			e.y = translateDisplayToImageYCoordinates(e.y);
+			e.x = chartCanvas.translateDisplayToImageXCoordinates(e.x);
+			e.y = chartCanvas.translateDisplayToImageYCoordinates(e.y);
 			if (timelineRect.contains(e.x, e.y)) {
 				setCursor(Display.getCurrent().getSystemCursor(SWT.CURSOR_HAND));
 			} else {


### PR DESCRIPTION
This PR removes the duplication of the `translateDisplayToImageCoordinates()` function that was borrowed from the `ChartCanvas`. This function has been changed from `private` to `protected` in an attempt to not expose it completely, and the `TimelineCanvas` and `ChartAndTextCanvases` have been relocated from `[..]/charts` to `[..]/misc` to live alongside the other canvas-related code. 