### PR TITLE
refactor ChartAndPopupTableUI to make it extend ChartAndTableUI

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ChartAndTableUI.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ChartAndTableUI.java
@@ -86,16 +86,16 @@ abstract class ChartAndTableUI implements IPageUI {
 	private static final String CHART = "chart"; //$NON-NLS-1$
 	private static final String SELECTED = "selected"; //$NON-NLS-1$
 	private static final int X_OFFSET = 180;
-	private final IItemFilter pageFilter;
-	private final StreamModel model;
+	private IItemFilter pageFilter;
+	protected StreamModel model;
 	protected CheckboxTableViewer chartLegend;
-	protected final Form form;
-	protected final Composite chartContainer;
-	protected final ChartCanvas chartCanvas;
-	protected final FilterComponent tableFilterComponent;
-	protected final ItemHistogram table;
-	protected final SashForm sash;
-	private final IPageContainer pageContainer;
+	protected Form form;
+	protected Composite chartContainer;
+	protected ChartCanvas chartCanvas;
+	protected FilterComponent tableFilterComponent;
+	protected ItemHistogram table;
+	protected SashForm sash;
+	private IPageContainer pageContainer;
 	protected List<IAction> allChartSeriesActions;
 	private IItemCollection selectionItems;
 	private IRange<IQuantity> timeRange;
@@ -103,6 +103,12 @@ abstract class ChartAndTableUI implements IPageUI {
 	protected FlavorSelector flavorSelector;
 
 	ChartAndTableUI(IItemFilter pageFilter, StreamModel model, Composite parent, FormToolkit toolkit,
+			IPageContainer pageContainer, IState state, String sectionTitle, IItemFilter tableFilter, Image icon,
+			FlavorSelectorState flavorSelectorState) {
+		init(pageFilter, model, parent, toolkit, pageContainer, state, sectionTitle, tableFilter, icon, flavorSelectorState);
+	}
+
+	protected void init(IItemFilter pageFilter, StreamModel model, Composite parent, FormToolkit toolkit,
 			IPageContainer pageContainer, IState state, String sectionTitle, IItemFilter tableFilter, Image icon,
 			FlavorSelectorState flavorSelectorState) {
 		this.pageFilter = pageFilter;

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/ChartFilterControlBar.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/ChartFilterControlBar.java
@@ -44,6 +44,7 @@ import org.eclipse.swt.widgets.Listener;
 import org.openjdk.jmc.common.unit.IQuantity;
 import org.openjdk.jmc.common.unit.IRange;
 import org.openjdk.jmc.ui.misc.ChartCanvas;
+import org.openjdk.jmc.ui.misc.PatternFly.Palette;
 import org.openjdk.jmc.ui.misc.TimeFilter;
 
 public class ChartFilterControlBar extends Composite {

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/XYChart.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/XYChart.java
@@ -102,9 +102,8 @@ public class XYChart {
 	}
 
 	// JFR Threads Page
-	public XYChart(IRange<IQuantity> range, IXDataRenderer rendererRoot, int xOffset, int yOffset, TimelineCanvas timelineCanvas, ChartFilterControlBar filterBar, ChartDisplayControlBar displayBar) {
+	public XYChart(IRange<IQuantity> range, IXDataRenderer rendererRoot, int xOffset, TimelineCanvas timelineCanvas, ChartFilterControlBar filterBar, ChartDisplayControlBar displayBar) {
 		this(range.getStart(), range.getEnd(), rendererRoot, xOffset);
-		this.yOffset = yOffset;
 		this.timelineCanvas = timelineCanvas;
 		this.filterBar = filterBar;
 		this.displayBar = displayBar;


### PR DESCRIPTION
This commit refactors a bit of the new `ChartAndPopupTableUI` such that it can extend `ChartAndTableUI` when being used for the Threads page.

This required adding an `init()` to the `ChartAndTableUI` constructor that contains the differing code between the two similar files and allows for the common variables to be shared instead of mimicing the code twice.