### PR TITLE
remove unused code from the ChartTextCanvas and ChartFilterControlBar

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ChartAndPopupTableUI.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ChartAndPopupTableUI.java
@@ -159,7 +159,6 @@ abstract class ChartAndPopupTableUI implements IPageUI {
 		};
 		filterBar = new ChartFilterControlBar(chartContainer, resetListener, pageContainer.getRecordingRange());
 		filterBar.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, false));
-		filterBar.setBackground(Palette.PF_BLACK_300.getSWTColor());
 
 		// Container to hold the chart (& timeline) and display toolbar
 		Composite graphContainer = toolkit.createComposite(chartContainer);

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/ChartFilterControlBar.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/ChartFilterControlBar.java
@@ -55,7 +55,7 @@ public class ChartFilterControlBar extends Composite {
 	public ChartFilterControlBar(Composite parent, Listener resetListener, IRange<IQuantity> recordingRange) {
 		super(parent, SWT.NO_BACKGROUND);
 		this.setLayout(new GridLayout(3, false));
-
+		this.setBackground(Palette.PF_BLACK_300.getSWTColor());
 		Label nameLabel = new Label(this, SWT.CENTER | SWT.HORIZONTAL);
 		nameLabel.setText(THREADS_LABEL);
 		GridData gd = new GridData(SWT.FILL, SWT.CENTER, false, true);


### PR DESCRIPTION
This PR removes some of the code that was borrowed from the `ChartCanvas` but doesn't affect the operation of the `ChartTextCanvas`.