### PR TITLE
fix table initialization when ThreadsPage calls saveTo()

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ChartAndPopupTableUI.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ChartAndPopupTableUI.java
@@ -51,6 +51,7 @@ import org.eclipse.swt.widgets.Listener;
 import org.eclipse.ui.forms.widgets.FormToolkit;
 
 import org.openjdk.jmc.common.IState;
+import org.openjdk.jmc.common.IWritableState;
 import org.openjdk.jmc.common.item.IItemCollection;
 import org.openjdk.jmc.common.item.IItemFilter;
 import org.openjdk.jmc.common.unit.IQuantity;
@@ -277,6 +278,12 @@ abstract class ChartAndPopupTableUI extends ChartAndTableUI {
 		} else if (table != null) {
 			table.show(items);
 		}
+	}
+
+	@Override
+	public void saveTo(IWritableState writableState) {
+		table = getUndisposedTable();
+		super.saveTo(writableState);
 	}
 
 	private void onSetRange(Boolean useRange) {


### PR DESCRIPTION
This PR addresses an oversight that was made in a recent commit [[0]](https://github.com/aptmac/jmc/commit/7165b8fc80cf8eb6253f2cb8b6b63db2fd2d8947) to have `ChartAndPopupTableUI` extend `ChartAndTableUI`.

The problem is that `table` is not assigned a value in the former, so when the `ThreadsPage` runs `saveTo()` it goes back to the `ChartAndTableUI` implementation which expects `table` to have a value, but it is null.

This PR re-introduces the `saveTo()` to `ChartAndPopupTableUI` which assigns a value to `table`, and then delegate back to `ChartAndTableUI.saveTo()`.

[0] https://github.com/aptmac/jmc/commit/7165b8fc80cf8eb6253f2cb8b6b63db2fd2d8947