### PR TITLE
Adjust old tests so they work again

### DIFF
--- a/application/uitests/org.openjdk.jmc.flightrecorder.uitest/src/test/java/org/openjdk/jmc/flightrecorder/uitest/JfrThreadsPageTest.java
+++ b/application/uitests/org.openjdk.jmc.flightrecorder.uitest/src/test/java/org/openjdk/jmc/flightrecorder/uitest/JfrThreadsPageTest.java
@@ -41,15 +41,20 @@ import org.openjdk.jmc.test.jemmy.MCUITestRule;
 import org.openjdk.jmc.test.jemmy.misc.wrappers.MCChartCanvas;
 import org.openjdk.jmc.test.jemmy.misc.wrappers.JfrNavigator;
 import org.openjdk.jmc.test.jemmy.misc.wrappers.JfrUi;
+import org.openjdk.jmc.test.jemmy.misc.wrappers.MCButton;
 import org.openjdk.jmc.test.jemmy.misc.wrappers.MCMenu;
 import org.openjdk.jmc.test.jemmy.misc.wrappers.MCTable;
+import org.openjdk.jmc.test.jemmy.misc.wrappers.MCToolBar;
 
 public class JfrThreadsPageTest extends MCJemmyTestBase {
 
 	private static final String PLAIN_JFR = "plain_recording.jfr";
 	private static final String TABLE_COLUMN_HEADER = "Thread";
+	private static final String OK_BUTTON = "OK";
 	private static final String HIDE_THREAD = org.openjdk.jmc.flightrecorder.ui.messages.internal.Messages.ThreadsPage_HIDE_THREAD_ACTION;
 	private static final String RESET_CHART = org.openjdk.jmc.flightrecorder.ui.messages.internal.Messages.ThreadsPage_RESET_CHART_TO_SELECTION_ACTION;
+	private static final String TABLE_TOOLTIP = org.openjdk.jmc.flightrecorder.ui.messages.internal.Messages.ThreadsPage_VIEW_THREAD_DETAILS;
+	private static final String TABLE_SHELL_TEXT = org.openjdk.jmc.flightrecorder.ui.messages.internal.Messages.ThreadsPage_TABLE_POPUP_TITLE;
 
 	private static MCChartCanvas chartCanvas;
 	private static MCTable threadsTable;
@@ -60,7 +65,6 @@ public class JfrThreadsPageTest extends MCJemmyTestBase {
 		public void before() {
 			JfrUi.openJfr(materialize("jfr", PLAIN_JFR, JfrThreadsPageTest.class));
 			JfrNavigator.selectTab(JfrUi.Tabs.THREADS);
-			threadsTable = MCTable.getByColumnHeader(TABLE_COLUMN_HEADER);
 			chartCanvas = MCChartCanvas.getChartCanvas();
 		}
 
@@ -72,7 +76,10 @@ public class JfrThreadsPageTest extends MCJemmyTestBase {
 
 	@Test
 	public void testMenuItemEnablement() {
+		openThreadsTable();
 		final int numThreads = threadsTable.getItemCount();
+		closeThreadsTable();
+
 		Assert.assertTrue(numThreads > 0);
 
 		Assert.assertFalse(chartCanvas.isContextMenuItemEnabled(RESET_CHART));
@@ -92,13 +99,19 @@ public class JfrThreadsPageTest extends MCJemmyTestBase {
 	@Test
 	public void testHideAllThreads() {
 		final int numSelection = 7;
+
+		openThreadsTable();
 		final int numThreads = threadsTable.getItemCount();
+		closeThreadsTable();
+
 		Assert.assertTrue(numThreads > 0 && numThreads >= numSelection);
 		Assert.assertTrue(chartCanvas.isContextMenuItemEnabled(HIDE_THREAD));
 		Assert.assertFalse(chartCanvas.isContextMenuItemEnabled(RESET_CHART));
 
+		openThreadsTable();
 		// Select a limited number of threads in the chart using the table
 		threadsTable.selectItems(0, numSelection - 1);
+		closeThreadsTable();
 
 		// Hide all the threads from the chart
 		for (int i = 0; i < numSelection; i++) {
@@ -115,5 +128,18 @@ public class JfrThreadsPageTest extends MCJemmyTestBase {
 		Assert.assertTrue(chartCanvas.isContextMenuItemEnabled(HIDE_THREAD));
 		Assert.assertFalse(chartCanvas.isContextMenuItemEnabled(RESET_CHART));
 	}
-}
 
+	private void openThreadsTable() {
+		MCToolBar.focusMc();
+		MCToolBar tb = MCToolBar.getByToolTip(TABLE_TOOLTIP);
+		tb.clickToolItem(TABLE_TOOLTIP);
+		threadsTable = MCTable.getByColumnHeader(TABLE_SHELL_TEXT, TABLE_COLUMN_HEADER);
+	}
+
+	private void closeThreadsTable() {
+		MCButton okButton = MCButton.getByLabel(TABLE_SHELL_TEXT, OK_BUTTON);
+		okButton.click();
+		MCToolBar.focusMc();
+	}
+
+}

--- a/application/uitests/org.openjdk.jmc.flightrecorder.uitest/src/test/java/org/openjdk/jmc/flightrecorder/uitest/JfrThreadsPageTest.java
+++ b/application/uitests/org.openjdk.jmc.flightrecorder.uitest/src/test/java/org/openjdk/jmc/flightrecorder/uitest/JfrThreadsPageTest.java
@@ -130,16 +130,21 @@ public class JfrThreadsPageTest extends MCJemmyTestBase {
 	}
 
 	private void openThreadsTable() {
-		MCToolBar.focusMc();
-		MCToolBar tb = MCToolBar.getByToolTip(TABLE_TOOLTIP);
-		tb.clickToolItem(TABLE_TOOLTIP);
-		threadsTable = MCTable.getByColumnHeader(TABLE_SHELL_TEXT, TABLE_COLUMN_HEADER);
+		if (threadsTable == null) {
+			MCToolBar.focusMc();
+			MCToolBar tb = MCToolBar.getByToolTip(TABLE_TOOLTIP);
+			tb.clickToolItem(TABLE_TOOLTIP);
+			threadsTable = MCTable.getByColumnHeader(TABLE_SHELL_TEXT, TABLE_COLUMN_HEADER);
+		}
 	}
 
 	private void closeThreadsTable() {
-		MCButton okButton = MCButton.getByLabel(TABLE_SHELL_TEXT, OK_BUTTON);
-		okButton.click();
-		MCToolBar.focusMc();
+		if (threadsTable != null) {
+			MCButton okButton = MCButton.getByLabel(TABLE_SHELL_TEXT, OK_BUTTON);
+			okButton.click();
+			threadsTable = null;
+			MCToolBar.focusMc();
+		}
 	}
 
 }

--- a/application/uitests/org.openjdk.jmc.test.jemmy/src/test/java/org/openjdk/jmc/test/jemmy/misc/base/wrappers/MCJemmyBase.java
+++ b/application/uitests/org.openjdk.jmc.test.jemmy/src/test/java/org/openjdk/jmc/test/jemmy/misc/base/wrappers/MCJemmyBase.java
@@ -214,6 +214,17 @@ public class MCJemmyBase {
 	}
 
 	/**
+	 * Gets a shell by text
+	 *
+	 * @param text
+	 *            the text string to lookup the shell with
+	 * @return the associated shell
+	 */
+	protected static Wrap<? extends Shell> getShellByText(String text) {
+		return Shells.SHELLS.lookup(Shell.class, new ByTextShell<>(text)).wrap();
+	}
+
+	/**
 	 * Tries to set focus on Mission Control
 	 */
 	public static void focusMc() {

--- a/application/uitests/org.openjdk.jmc.test.jemmy/src/test/java/org/openjdk/jmc/test/jemmy/misc/wrappers/MCButton.java
+++ b/application/uitests/org.openjdk.jmc.test.jemmy/src/test/java/org/openjdk/jmc/test/jemmy/misc/wrappers/MCButton.java
@@ -96,6 +96,19 @@ public class MCButton extends MCJemmyBase {
 	}
 
 	/**
+	 * Finds a button in a shell with the given text and returns it.
+	 *
+	 * @param label
+	 *            the label string of the button
+	 * @param shellText
+	 *            the text to look up the shell that the button is contained in
+	 * @return a {@link MCButton} in the shell matching the label
+	 */
+	public static MCButton getByLabel(String  shellText, String label) {
+		return getByLabel(getShellByText(shellText), label);
+	}
+
+	/**
 	 * Finds a button by button label and returns it
 	 *
 	 * @param shell

--- a/application/uitests/org.openjdk.jmc.test.jemmy/src/test/java/org/openjdk/jmc/test/jemmy/misc/wrappers/MCTable.java
+++ b/application/uitests/org.openjdk.jmc.test.jemmy/src/test/java/org/openjdk/jmc/test/jemmy/misc/wrappers/MCTable.java
@@ -281,6 +281,19 @@ public class MCTable extends MCJemmyBase {
 	/**
 	 * Finds tables by column header (first match only)
 	 *
+	 * @param shellText
+	 *            text to look up the shell that contains the table
+	 * @param headerName
+	 *            the name of the column header
+	 * @return a {@link MCTable}
+	 */
+	public static MCTable getByColumnHeader(String shellText , String headerName) {
+		return getByColumnHeader(getShellByText(shellText), headerName);
+	}
+
+	/**
+	 * Finds tables by column header (first match only)
+	 *
 	 * @param shell
 	 *            the shell in which to look for the table
 	 * @param headerName


### PR DESCRIPTION
This patch adjusts old tests for the jfrThreadsPage so that they work properly.  This involved ensuring that all function calls on the threads table are performed when the popup table is open and all chart calls are performed when the table is closed.