### PR TITLE
fix rendering regression when selecting threads in the popup chart

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ChartAndPopupTableUI.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ChartAndPopupTableUI.java
@@ -85,6 +85,7 @@ abstract class ChartAndPopupTableUI extends ChartAndTableUI {
 	private static final String SELECTED = "selected"; //$NON-NLS-1$
 	private static final int TIMELINE_HEIGHT = 40;
 	private static final int X_OFFSET = 0;
+	private static final int Y_OFFSET = 0;
 	protected ChartFilterControlBar filterBar;
 	protected ChartTextCanvas textCanvas;
 	protected ItemHistogram hiddenTable;
@@ -239,7 +240,7 @@ abstract class ChartAndPopupTableUI extends ChartAndTableUI {
 		PersistableSashForm.loadState(sash, state.getChild(SASH));
 		DataPageToolkit.createChartTimestampTooltip(chartCanvas);
 
-		chart = new XYChart(pageContainer.getRecordingRange(), RendererToolkit.empty(), X_OFFSET, timelineCanvas, filterBar, displayBar);
+		chart = new XYChart(pageContainer.getRecordingRange(), RendererToolkit.empty(), X_OFFSET, Y_OFFSET, timelineCanvas, filterBar, displayBar);
 		DataPageToolkit.setChart(chartCanvas, chart, pageContainer::showSelection);
 		DataPageToolkit.setChart(textCanvas, chart, pageContainer::showSelection);
 		SelectionStoreActionToolkit.addSelectionStoreRangeActions(pageContainer.getSelectionStore(), chart,

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/XYChart.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/XYChart.java
@@ -102,8 +102,9 @@ public class XYChart {
 	}
 
 	// JFR Threads Page
-	public XYChart(IRange<IQuantity> range, IXDataRenderer rendererRoot, int xOffset, TimelineCanvas timelineCanvas, ChartFilterControlBar filterBar, ChartDisplayControlBar displayBar) {
+	public XYChart(IRange<IQuantity> range, IXDataRenderer rendererRoot, int xOffset, Integer yOffset, TimelineCanvas timelineCanvas, ChartFilterControlBar filterBar, ChartDisplayControlBar displayBar) {
 		this(range.getStart(), range.getEnd(), rendererRoot, xOffset);
+		this.yOffset = yOffset;
 		this.timelineCanvas = timelineCanvas;
 		this.filterBar = filterBar;
 		this.displayBar = displayBar;

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartTextCanvas.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartTextCanvas.java
@@ -208,7 +208,7 @@ public class ChartTextCanvas extends Canvas {
 		@Override
 		public void paintControl(PaintEvent e) {
 			Rectangle rect = new Rectangle(0, 0, getParent().getSize().x, getParent().getSize().y);
-			if (getNumItems() != 1 || !(MIN_LANE_HEIGHT * getNumItems() < rect.height)) {
+			if (getNumItems() != 1 && !(MIN_LANE_HEIGHT * getNumItems() < rect.height)) {
 				rect.height = MIN_LANE_HEIGHT * getNumItems();
 			}
 


### PR DESCRIPTION
This PR fixes a regression from two previous commits related to code cleanup. I shouldn't have removed the `yOffset` in the `XYChart`, and the if-statement in the text canvas has been corrected.