### PR TITLE
Test selection in popup table

### DIFF
--- a/application/uitests/org.openjdk.jmc.flightrecorder.uitest/src/test/java/org/openjdk/jmc/flightrecorder/uitest/JfrThreadsPageTest.java
+++ b/application/uitests/org.openjdk.jmc.flightrecorder.uitest/src/test/java/org/openjdk/jmc/flightrecorder/uitest/JfrThreadsPageTest.java
@@ -129,6 +129,24 @@ public class JfrThreadsPageTest extends MCJemmyTestBase {
 		Assert.assertFalse(chartCanvas.isContextMenuItemEnabled(RESET_CHART));
 	}
 
+	@Test
+	public void testPopupTableSelection() {
+		openThreadsTable();
+		final int numSelection = 7;
+		final int numThreads = threadsTable.getItemCount();
+		Assert.assertTrue(numThreads > 0 && numThreads >= numSelection);
+
+		threadsTable.selectItems(0, numSelection - 1);
+		int originalSelection = threadsTable.getSelectionCount();
+		Assert.assertEquals(numSelection, originalSelection);
+		closeThreadsTable();
+
+		openThreadsTable();
+		int newSelection = threadsTable.getSelectionCount();
+		Assert.assertEquals(newSelection, originalSelection);
+		closeThreadsTable();
+	}
+
 	private void openThreadsTable() {
 		if (threadsTable == null) {
 			MCToolBar.focusMc();

--- a/application/uitests/org.openjdk.jmc.test.jemmy/src/test/java/org/openjdk/jmc/test/jemmy/misc/wrappers/MCTable.java
+++ b/application/uitests/org.openjdk.jmc.test.jemmy/src/test/java/org/openjdk/jmc/test/jemmy/misc/wrappers/MCTable.java
@@ -529,6 +529,24 @@ public class MCTable extends MCJemmyBase {
 	}
 
 	/**
+	 * Gets the number of items selected in the table
+	 *
+	 * @return the number of items selected in the table
+	 */
+	public int getSelectionCount() {
+		final Table table = getWrap().getControl();
+		Fetcher<Integer> fetcher = new Fetcher<Integer>() {
+			@Override
+			public void run() {
+				int count = table.getSelectionCount();
+				setOutput(count);
+			}
+		};
+		Display.getDefault().syncExec(fetcher);
+		return fetcher.getOutput().intValue();
+	}
+
+	/**
 	 * Whether or not the table contains the text given
 	 *
 	 * @param item


### PR DESCRIPTION
Add test to check selection in the pop-up table and to make sure selection persists across closing and then reopening the table.