### PR TITLE
fix org.openjdk.jmc.ui SpotBugs flagged issues

### DIFF
--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/XYChart.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/XYChart.java
@@ -385,11 +385,11 @@ public class XYChart {
 
 		// if panning would flow over the recording range start or end time,
 		// calculate the difference and add it so the other side.
-		if (newStart.compareTo(start) == -1) {
+		if (newStart.compareTo(start) < 0) {
 			IQuantity diff = start.subtract(newStart);
 			newStart = start;
 			newEnd = newEnd.add(diff);
-		} else if (newEnd.compareTo(end) == 1) {
+		} else if (newEnd.compareTo(end) > 0) {
 			IQuantity diff = newEnd.subtract(end);
 			newStart = newStart.add(diff);
 			newEnd = end;
@@ -508,11 +508,11 @@ public class XYChart {
 
 		// if zooming out would flow over the recording range start or end time,
 		// calculate the difference and add it to the other side.
-		if (newStart.compareTo(start) == -1) {
+		if (newStart.compareTo(start) < 0) {
 			IQuantity diff = start.subtract(newStart);
 			newStart = start;
 			newEnd = newEnd.add(diff);
-		} else if (newEnd.compareTo(end) == 1) {
+		} else if (newEnd.compareTo(end) > 0) {
 			IQuantity diff = newEnd.subtract(end);
 			newStart = newStart.subtract(diff);
 			newEnd = end;
@@ -675,7 +675,6 @@ public class XYChart {
 		} else {
 			boolean nestedHasPayload = false;
 			for (IRenderedRow nestedRow : row.getNestedRows()) {
-				row.getNestedRows().size();
 				int yRowEnd = yRowStart + nestedRow.getHeight();
 				if (yRowStart > ySelectionEnd) {
 					break;

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartCanvas.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartCanvas.java
@@ -557,9 +557,6 @@ public class ChartCanvas extends Canvas {
 			}
 		}, lastMouseX, lastMouseY);
 		// Attempt to reduce flicker by avoiding unnecessary updates.
-		if (highlightRects != null) {
-			highlightRects.size();
-		}
 		if (!newRects.equals(highlightRects)) {
 			highlightRects = newRects;
 			if (textCanvas != null) {

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/TimeDisplay.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/TimeDisplay.java
@@ -50,9 +50,10 @@ import org.openjdk.jmc.ui.misc.PatternFly.Palette;
 
 public class TimeDisplay extends Composite {
 
-		private final String TIME_FORMAT_REGEX = "\\d{2}\\:\\d{2}\\:\\d{2}\\:\\d{3}";
+		private static final String TIME_FORMAT_REGEX = "\\d{2}\\:\\d{2}\\:\\d{2}\\:\\d{3}";
+		private static final String DIGIT_FORMAT_REGEX = "\\d{3}|\\d{2}";
 		private final Pattern timePattern = Pattern.compile(TIME_FORMAT_REGEX);
-		private final Pattern digitPattern = Pattern.compile("\\d{3}|\\d{2}");
+		private final Pattern digitPattern = Pattern.compile(DIGIT_FORMAT_REGEX);
 		private Calendar currentCalendar; // currently active time in Calendar form
 		private IQuantity currentTime; // currently active time
 		private IQuantity displayTime; // time shown in the widget (may or not be what's active)

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/TimeFilter.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/TimeFilter.java
@@ -51,14 +51,12 @@ import org.openjdk.jmc.ui.charts.XYChart;
 public class TimeFilter extends Composite {
 
 	private ChartCanvas chartCanvas;
-	private IRange<IQuantity> recordingRange;
 	private XYChart chart;
 	private TimeDisplay startDisplay;
 	private TimeDisplay endDisplay;
 
 	public TimeFilter(Composite parent, IRange<IQuantity> recordingRange, Listener resetListener) {
 		super(parent, SWT.NO_BACKGROUND);
-		this.recordingRange = recordingRange;
 		this.setLayout(new GridLayout(7, false));
 		Label eventsLabel = new Label(this, SWT.LEFT);
 		eventsLabel.setText(Messages.TimeFilter_FILTER_EVENTS);


### PR DESCRIPTION
There were a handful of issues that SpotBugs found when running a `mvn verify`.

The first being that `.compareTo()` should not check specific values, but rather if the result is positive or negative.

There were also a couple instances of left behind lines that I was using as breakpoints to check values during debugging.

And lastly regex strings need to be static.

After fixing these I see:
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 12:16 min
[INFO] Finished at: 2019-10-17T12:24:33-04:00
[INFO] ------------------------------------------------------------------------
```