### PR TITLE
add translateDisplayToImageCoordinates() to the canvas select methods

### DIFF
--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartCanvas.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartCanvas.java
@@ -601,7 +601,9 @@ public class ChartCanvas extends Canvas {
 	}
 
 	private void select(int x1, int x2, int y1, int y2, boolean clear) {
-		if ((awtChart != null) && awtChart.select(x1, x2, y1, y2, clear)) {
+		Point p1 = translateDisplayToImageCoordinates(x1, y1);
+		Point p2 = translateDisplayToImageCoordinates(x2, y2);
+		if ((awtChart != null) && awtChart.select(p1.x, p2.x, p1.y, p2.y, clear)) {
 			redrawChart();
 			redrawChartText();
 		}

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartTextCanvas.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartTextCanvas.java
@@ -338,7 +338,9 @@ public class ChartTextCanvas extends Canvas {
 	}
 
 	public void select(int x1, int x2, int y1, int y2, boolean clear) {
-		if ((awtChart != null) && awtChart.select(x1, x2, y1, y2, clear)) {
+		Point p1 = chartCanvas.translateDisplayToImageCoordinates(x1, y1);
+		Point p2 = chartCanvas.translateDisplayToImageCoordinates(x2, y2);
+		if ((awtChart != null) && awtChart.select(p1.x, p2.x, p1.y, p2.y, clear)) {
 			redrawChartText();
 			redrawChart();
 		}


### PR DESCRIPTION
This PR addresses an issue [[0]](https://trello.com/c/LNSVXLCR/65-chart-text-canvas-ctrl-shift-click-mechanics-not-registering-clicks-where-intended) where control and shift clicks weren't registering properly on displays with abnormally large text. For whatever reason, when running JMC as an RCP application on my machine the fonts display larger than usual. In the case of the Threads page it caused control and shift clicks to not register properly. This patch adds the `translateDisplayToImageCoordinates()` to the `select()` methods of the chart and text canvases, which fixes this issue.

![issue](https://trello-attachments.s3.amazonaws.com/5d3b2272fd11de3e33d5fbd0/5d9c9d523d7ba71f51c47358/4d252515224cd8c543de3a59890dcc9b/2019-10-08-text-canvas-scaling.gif)

[0] https://trello.com/c/LNSVXLCR/65-chart-text-canvas-ctrl-shift-click-mechanics-not-registering-clicks-where-intended