### PR TITLE
Test reset buttons

### DIFF
--- a/application/uitests/org.openjdk.jmc.flightrecorder.uitest/src/test/java/org/openjdk/jmc/flightrecorder/uitest/JfrThreadsPageTest.java
+++ b/application/uitests/org.openjdk.jmc.flightrecorder.uitest/src/test/java/org/openjdk/jmc/flightrecorder/uitest/JfrThreadsPageTest.java
@@ -44,13 +44,20 @@ import org.openjdk.jmc.test.jemmy.misc.wrappers.JfrUi;
 import org.openjdk.jmc.test.jemmy.misc.wrappers.MCButton;
 import org.openjdk.jmc.test.jemmy.misc.wrappers.MCMenu;
 import org.openjdk.jmc.test.jemmy.misc.wrappers.MCTable;
+import org.openjdk.jmc.test.jemmy.misc.wrappers.MCText;
 import org.openjdk.jmc.test.jemmy.misc.wrappers.MCToolBar;
+import org.openjdk.jmc.ui.UIPlugin;
 
 public class JfrThreadsPageTest extends MCJemmyTestBase {
 
 	private static final String PLAIN_JFR = "plain_recording.jfr";
 	private static final String TABLE_COLUMN_HEADER = "Thread";
 	private static final String OK_BUTTON = "OK";
+	private static final String RESET_BUTTON = "Reset";
+	private static final String FILTER_BUTTON = "Filter";
+	private static final String START_TIME = "08:06:19:489";
+	private static final String NEW_START_TIME = "08:06:19:500";
+	private static final String DEFAULT_ZOOM = "100.00 %";
 	private static final String HIDE_THREAD = org.openjdk.jmc.flightrecorder.ui.messages.internal.Messages.ThreadsPage_HIDE_THREAD_ACTION;
 	private static final String RESET_CHART = org.openjdk.jmc.flightrecorder.ui.messages.internal.Messages.ThreadsPage_RESET_CHART_TO_SELECTION_ACTION;
 	private static final String TABLE_TOOLTIP = org.openjdk.jmc.flightrecorder.ui.messages.internal.Messages.ThreadsPage_VIEW_THREAD_DETAILS;
@@ -73,6 +80,34 @@ public class JfrThreadsPageTest extends MCJemmyTestBase {
 			MCMenu.closeActiveEditor();
 		}
 	};
+
+	@Test
+	public void testResetButtons() {
+		MCText StartTimeField = MCText.getByText(START_TIME);
+		MCText zoomDisplay = MCText.getByText(DEFAULT_ZOOM);
+		MCButton filterBtn = MCButton.getByLabel(FILTER_BUTTON);
+		MCButton resetBtn = MCButton.getByLabel(RESET_BUTTON);
+		MCButton scaleToFitBtn = MCButton.getByImage(
+				UIPlugin.getDefault().getImage(UIPlugin.ICON_FA_SCALE_TO_FIT));
+
+		StartTimeField.setText(NEW_START_TIME);
+		filterBtn.click();
+		Assert.assertNotEquals(START_TIME, StartTimeField.getText());
+		Assert.assertNotEquals(zoomDisplay.getText(), DEFAULT_ZOOM);
+
+		resetBtn.click();
+		Assert.assertEquals(START_TIME, StartTimeField.getText());
+		Assert.assertEquals(zoomDisplay.getText(), DEFAULT_ZOOM);
+
+		StartTimeField.setText(NEW_START_TIME);
+		filterBtn.click();
+		Assert.assertNotEquals(START_TIME, StartTimeField.getText());
+		Assert.assertNotEquals(zoomDisplay.getText(), DEFAULT_ZOOM);
+
+		scaleToFitBtn.click();
+		Assert.assertEquals(zoomDisplay.getText(), DEFAULT_ZOOM);
+		Assert.assertEquals(START_TIME, StartTimeField.getText());
+	}
 
 	@Test
 	public void testMenuItemEnablement() {

--- a/application/uitests/org.openjdk.jmc.test.jemmy/src/test/java/org/openjdk/jmc/test/jemmy/misc/wrappers/MCButton.java
+++ b/application/uitests/org.openjdk.jmc.test.jemmy/src/test/java/org/openjdk/jmc/test/jemmy/misc/wrappers/MCButton.java
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.jface.dialogs.IDialogConstants;
+import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
@@ -58,6 +59,45 @@ public class MCButton extends MCJemmyBase {
 
 	private MCButton(Wrap<? extends Button> button) {
 		this.control = button;
+	}
+
+	/**
+	 * Finds a button in the supplied shell by image and returns it.
+	 *
+	 * @param shell
+	 *            the shell where to search for the button
+	 * @param image
+	 *            the image to look up the button with
+	 * @return a {@link MCButton} (possibly null)
+	 */
+	@SuppressWarnings("unchecked")
+	public static MCButton getByImage(Wrap<? extends Shell> shell, Image image) {
+		List<Wrap<? extends Button>> allVisibleButtonWraps = getVisible(
+				shell.as(Parent.class, Button.class).lookup(Button.class));
+		for (final Wrap<? extends Button> buttonWrap : allVisibleButtonWraps) {
+			Fetcher<Image> fetcher = new Fetcher<Image>() {
+				@Override
+				public void run() {
+					setOutput(buttonWrap.getControl().getImage());
+				}
+			};
+			Display.getDefault().syncExec(fetcher);
+			if (image.equals(fetcher.getOutput())) {
+				return new MCButton(buttonWrap);
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Finds a button in the default Mission Control shell and returns it.
+	 *
+	 * @param image
+	 *            the image of the button
+	 * @return a {@link MCButton} in the default shell matching the image.
+	 */
+	public static MCButton getByImage(Image image) {
+		return getByImage(getShell(), image);
 	}
 
 	/**


### PR DESCRIPTION
This patch adds a reset buttons test.  The test makes sure that the reset time filter button and the scale to fit button properly reset the chart's display to its default view on click.