### PR TITLE
remove redundant calls resulting in redrawing the chart and timeline canvas

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ChartAndPopupTableUI.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ChartAndPopupTableUI.java
@@ -247,7 +247,6 @@ abstract class ChartAndPopupTableUI extends ChartAndTableUI {
 		SelectionStoreActionToolkit.addSelectionStoreRangeActions(pageContainer.getSelectionStore(), chart,
 				JfrAttributes.LIFETIME, NLS.bind(Messages.ChartAndTableUI_TIMELINE_SELECTION, form.getText()),
 				chartCanvas.getContextMenu());
-		buildChart();
 
 		// Wire-up the chart & text canvases to the filter and display bars
 		displayBar.setChart(chart);

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/XYChart.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/XYChart.java
@@ -65,6 +65,7 @@ public class XYChart {
 	private IQuantity rangeDuration;
 	private IXDataRenderer rendererRoot;
 	private IRenderedRow rendererResult;
+	private boolean isRangeUpdated;
 	private final int xOffset;
 	private int yOffset = 35;
 	private final int bucketWidth;
@@ -135,6 +136,7 @@ public class XYChart {
 		this.end = end;
 		this.xOffset = xOffset;
 		this.bucketWidth = bucketWidth;
+		isRangeUpdated = false;
 	}
 	
 	public void setRendererRoot(IXDataRenderer rendererRoot) {
@@ -200,8 +202,9 @@ public class XYChart {
 		int x1 = (int) fullRangeAxis.getPixel(currentStart);
 		int x2 = (int) Math.ceil(fullRangeAxis.getPixel(currentEnd));
 		
-		if (timelineCanvas != null) {
+		if (timelineCanvas != null && isRangeUpdated) {
 			timelineCanvas.renderRangeIndicator(x1, x2);
+			isRangeUpdated = false;
 		} else {
 			context.setPaint(RANGE_INDICATION_COLOR);
 			context.fillRect(x1, rangeIndicatorY, x2 - x1, RANGE_INDICATOR_HEIGHT);
@@ -608,6 +611,7 @@ public class XYChart {
 				filterBar.setEndTime(currentEnd);
 			}
 			rangeListeners.stream().forEach(l -> l.accept(getVisibleRange()));
+			isRangeUpdated = true;
 		}
 	}
 
@@ -669,7 +673,7 @@ public class XYChart {
 	}
 
 	private boolean addSelectedRows(IRenderedRow row, int yRowStart, int ySelectionStart, int ySelectionEnd) {
-		List<IRenderedRow> subdivision = row.getNestedRows(); // height 1450, has all 32 rows
+		List<IRenderedRow> subdivision = row.getNestedRows();
 		if (subdivision.isEmpty()) {
 			return addPayload(row);
 		} else {

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartCanvas.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartCanvas.java
@@ -650,7 +650,6 @@ public class ChartCanvas extends Canvas {
 	public void setChart(XYChart awtChart) {
 		this.awtChart = awtChart;
 		notifyListener();
-		redrawChart();
 	}
 
 	public void setTextCanvas(ChartTextCanvas textCanvas) {

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartTextCanvas.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartTextCanvas.java
@@ -360,7 +360,6 @@ public class ChartTextCanvas extends Canvas {
 	public void setChart(XYChart awtChart) {
 		this.awtChart = awtChart;
 		notifyListener();
-		redrawChartText();
 	}
 
 	public void setChartCanvas(ChartCanvas chartCanvas) {


### PR DESCRIPTION
This PR addresses an issue where the rendering functions are called more than they have to be.

For example, `buildChart()` is called in `ChartAndPopupTableUI`, only to be called again by the `ThreadsPage`. Additionally the timeline canvas was re-rendered on many chart events (including basic lane highlighting), and is now gated by a boolean flag to update only if the visible range was modified.