### PR TITLE
Add Tooltips to the Display Bar & Use the Palette for thread lanes

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/DropdownLaneFilter.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/DropdownLaneFilter.java
@@ -68,7 +68,15 @@ public class DropdownLaneFilter extends Composite {
 		this.lanes = lanes;
 		this.mm = mm;
 		this.layout = createGridLayout();
-		this.shellDisposeAdapter = createDisposeAdapter();
+		this.shellDisposeAdapter = new ShellAdapter() {
+			public void shellDeactivated(ShellEvent event) {
+				if (dropdownButton.isDisposed()) { return; }
+				if (dropdownButton.getSelection()) {
+					disposeDropdown();
+					dropdownButton.setSelection(false);
+				}
+			}
+		};
 		setLayout(layout);
 		dropdownButton = new Button(this, SWT.TOGGLE);
 		dropdownButton.setLayoutData(new GridData(GridData.FILL_BOTH));
@@ -120,22 +128,6 @@ public class DropdownLaneFilter extends Composite {
 		layout.marginHeight = 0;
 		layout.marginWidth = 0;
 		return layout;
-	}
-
-	/**
-	 * Prepares the ShellAdapter which will be used when the dropdown
-	 * is to be disposed of.
-	 * @return ShellAdapter to be used by the dropdown shell
-	 */
-	private ShellAdapter createDisposeAdapter() {
-		return new ShellAdapter() {
-			public void shellDeactivated(ShellEvent event) {
-				if (dropdownButton.getSelection()) {
-					disposeDropdown();
-					dropdownButton.setSelection(false);
-				}
-			}
-		};
 	}
 
 	/**

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/TypeLabelProvider.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/TypeLabelProvider.java
@@ -36,40 +36,85 @@ import java.awt.Color;
 
 import org.openjdk.jmc.common.util.ColorToolkit;
 import org.openjdk.jmc.flightrecorder.jdk.JdkTypeIDs;
+import org.openjdk.jmc.ui.misc.PatternFly.Palette;
 
 // May evolve into a label provider
 public class TypeLabelProvider {
 
 	public static Color getColor(String typeId) {
 		switch (typeId) {
-		case JdkTypeIDs.ERRORS_THROWN:
-			return new Color(0xFF0000);
-		case JdkTypeIDs.EXCEPTIONS_THROWN:
-			return new Color(0xC80000);
+		case JdkTypeIDs.RECORDINGS:
+			return Palette.PF_CYAN_300.getAWTColor();
+		case JdkTypeIDs.RECORDING_SETTING:
+			return Palette.PF_GREEN_300.getAWTColor();
+		case JdkTypeIDs.THROWABLES_STATISTICS:
+			return Palette.PF_GOLD_500.getAWTColor();
+		case JdkTypeIDs.BIASED_LOCK_CLASS_REVOCATION:
+			return Palette.PF_PURPLE_400.getAWTColor();
+		case JdkTypeIDs.BIASED_LOCK_REVOCATION:
+			return Palette.PF_LIGHT_GREEN_300.getAWTColor();
+		case JdkTypeIDs.BIASED_LOCK_SELF_REVOCATION:
+			return Palette.PF_LIGHT_GREEN_400.getAWTColor();
 		case JdkTypeIDs.FILE_READ:
-			return new Color(0xBE4422);
+			return Palette.PF_ORANGE_400.getAWTColor();
 		case JdkTypeIDs.FILE_WRITE:
-			return new Color(0x2C689E);
+			return Palette.PF_CYAN_600.getAWTColor();
+		case JdkTypeIDs.ERRORS_THROWN:
+			return Palette.PF_RED_100.getAWTColor();
+		case JdkTypeIDs.EXCEPTIONS_THROWN:
+			return Palette.PF_RED_300.getAWTColor();
 		case JdkTypeIDs.MONITOR_ENTER:
-			return new Color(0xFF6D64);
+			return Palette.PF_ORANGE_200.getAWTColor();
 		case JdkTypeIDs.MONITOR_WAIT:
-			return new Color(0xFFE75B);
+			return Palette.PF_GOLD_200.getAWTColor();
+		case JdkTypeIDs.THREAD_PARK:
+			return Palette.PF_BLACK_500.getAWTColor();
+		case JdkTypeIDs.THREAD_SLEEP:
+			return Palette.PF_BLUE_500.getAWTColor();
+		case JdkTypeIDs.OLD_OBJECT_SAMPLE:
+			return Palette.PF_CYAN_200.getAWTColor();
+		case JdkTypeIDs.SWEEP_CODE_CACHE:
+			return Palette.PF_LIGHT_GREEN_500.getAWTColor();
+		case JdkTypeIDs.SOCKET_READ:
+			return Palette.PF_RED_200.getAWTColor();
+		case JdkTypeIDs.SOCKET_WRITE:
+			return Palette.PF_LIGHT_BLUE_500.getAWTColor();
+		case JdkTypeIDs.CLASS_LOAD:
+			return Palette.PF_PURPLE_100.getAWTColor();
+		case JdkTypeIDs.COMPILATION:
+			return Palette.PF_GOLD_300.getAWTColor();
+		case JdkTypeIDs.GC_PAUSE:
+			return Palette.PF_ORANGE_500.getAWTColor();
+		case JdkTypeIDs.GC_PAUSE_L1:
+			return Palette.PF_GOLD_400.getAWTColor();
+		case JdkTypeIDs.GC_PAUSE_L2:
+			return Palette.PF_BLUE_400.getAWTColor();
+		case JdkTypeIDs.GC_PAUSE_L3:
+			return Palette.PF_PURPLE_300.getAWTColor();
+		case JdkTypeIDs.GC_PAUSE_L4:
+			return Palette.PF_LIGHT_GREEN_600.getAWTColor();
+		case JdkTypeIDs.SAFEPOINT_BEGIN:
+			return Palette.PF_PURPLE_200.getAWTColor();
+		case JdkTypeIDs.SAFEPOINT_CLEANUP:
+			return Palette.PF_PURPLE_500.getAWTColor();
+		case JdkTypeIDs.SAFEPOINT_CLEANUP_TASK:
+			return Palette.PF_BLUE_300.getAWTColor();
+		case JdkTypeIDs.SAFEPOINT_END:
+			return Palette.PF_GREEN_400.getAWTColor();
+		case JdkTypeIDs.SAFEPOINT_STATE_SYNC:
+			return Palette.PF_LIGHT_GREEN_200.getAWTColor();
+		case JdkTypeIDs.SAFEPOINT_WAIT_BLOCKED:
+			return Palette.PF_GREEN_500.getAWTColor();
+		case JdkTypeIDs.VM_OPERATIONS:
+			return Palette.PF_ORANGE_500.getAWTColor();
 		case JdkTypeIDs.ALLOC_INSIDE_TLAB:
 			return new Color(0xFF8000);
 		case JdkTypeIDs.ALLOC_OUTSIDE_TLAB:
 			return new Color(0x808000);
-		case JdkTypeIDs.SOCKET_READ:
-			return new Color(0xC8321E);
-		case JdkTypeIDs.SOCKET_WRITE:
-			return new Color(0x4678C8);
-		case JdkTypeIDs.THREAD_PARK:
-			return new Color(0x808080);
 		case JdkTypeIDs.JAVA_THREAD_END:
 			return new Color(0x408040);
 		case JdkTypeIDs.JAVA_THREAD_START:
 			return new Color(0x80FF80);
-		case JdkTypeIDs.CLASS_LOAD:
-			return new Color(0x9B81DB);
 		case JdkTypeIDs.CLASS_UNLOAD:
 			return new Color(0x00FF00);
 		case JdkTypeIDs.COMPILER_FAILURE:
@@ -84,26 +129,12 @@ public class TypeLabelProvider {
 			return new Color(0xFF0000);
 		case JdkTypeIDs.GC_DETAILED_PROMOTION_FAILED:
 			return new Color(0xD04E4E);
-		case JdkTypeIDs.GC_PAUSE:
-			return new Color(0xDC3C00);
-		case JdkTypeIDs.GC_PAUSE_L1:
-			return new Color(0xE6CB45);
-		case JdkTypeIDs.GC_PAUSE_L2:
-			return new Color(0x458AE6);
-		case JdkTypeIDs.GC_PAUSE_L3:
-			return new Color(0xE645E2);
-		case JdkTypeIDs.GC_PAUSE_L4:
-			return new Color(0x85A115);
 		case JdkTypeIDs.EXECUTION_SAMPLE:
 			return new Color(0xCC66FF);
 		case JdkTypeIDs.EXECUTION_SAMPLING_INFO_EVENT_ID:
 			return new Color(0xE6C940);
-		case JdkTypeIDs.VM_OPERATIONS:
-			return new Color(0xBA6F1F);
 		case JdkTypeIDs.PROCESSES:
 			return new Color(0xE37A44);
-		case JdkTypeIDs.COMPILATION:
-			return new Color(0xF7EA2A);
 		case JdkTypeIDs.CONCURRENT_MODE_FAILURE:
 			return new Color(0xFF0000);
 		case JdkTypeIDs.CONTEXT_SWITCH_RATE:

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartDisplayControlBar.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartDisplayControlBar.java
@@ -108,6 +108,7 @@ public class ChartDisplayControlBar extends Composite {
 		selectionBtn.setLayoutData(new GridData(SWT.CENTER, SWT.CENTER, false, false));
 		selectionBtn.setImage(UIPlugin.getDefault().getImage(UIPlugin.ICON_FA_SELECTION));
 		selectionBtn.setSelection(true);
+		selectionBtn.setToolTipText(Messages.ChartDisplayControlBar_SELECTION_TOOL_TOOLTIP);
 		selectionBtn.addListener(SWT.Selection, new Listener() {
 			@Override
 			public void handleEvent(Event event) {
@@ -121,6 +122,11 @@ public class ChartDisplayControlBar extends Composite {
 		zoomInBtn.setLayoutData(new GridData(SWT.CENTER, SWT.CENTER, false, false));
 		zoomInBtn.setImage(UIPlugin.getDefault().getImage(UIPlugin.ICON_FA_ZOOM_IN));
 		zoomInBtn.setSelection(false);
+		StringBuilder sb = new StringBuilder();
+		sb.append(Messages.ChartDisplayControlBar_ZOOM_IN_CLICK_TOOLTIP);
+		sb.append(System.getProperty("line.separator"));
+		sb.append(Messages.ChartDisplayControlBar_ZOOM_IN_HOLD_TOOLTIP);
+		zoomInBtn.setToolTipText(sb.toString());
 		zoomInBtn.addListener(SWT.Selection,  new Listener() {
 			@Override
 			public void handleEvent(Event event) {
@@ -152,6 +158,11 @@ public class ChartDisplayControlBar extends Composite {
 		zoomOutBtn.setLayoutData(new GridData(SWT.CENTER, SWT.CENTER, false, false));
 		zoomOutBtn.setImage(UIPlugin.getDefault().getImage(UIPlugin.ICON_FA_ZOOM_OUT));
 		zoomOutBtn.setSelection(false);
+		sb = new StringBuilder();
+		sb.append(Messages.ChartDisplayControlBar_ZOOM_OUT_CLICK_TOOLTIP);
+		sb.append(System.getProperty("line.separator"));
+		sb.append(Messages.ChartDisplayControlBar_ZOOM_OUT_HOLD_TOOLTIP);
+		zoomOutBtn.setToolTipText(sb.toString());
 		zoomOutBtn.addListener(SWT.Selection,  new Listener() {
 			@Override
 			public void handleEvent(Event e) {
@@ -171,6 +182,7 @@ public class ChartDisplayControlBar extends Composite {
 		zoomPanBtn.setLayoutData(new GridData(SWT.CENTER, SWT.CENTER, false, false));
 		zoomPanBtn.setImage(UIPlugin.getDefault().getImage(UIPlugin.ICON_FA_ZOOM_PAN));
 		zoomPanBtn.setSelection(false);
+		zoomPanBtn.setToolTipText(Messages.ChartDisplayControlBar_ZOOM_PAN_TOOLTIP);
 		zoomPanBtn.addListener(SWT.Selection, new Listener() {
 			@Override
 			public void handleEvent(Event event) {
@@ -183,6 +195,7 @@ public class ChartDisplayControlBar extends Composite {
 		scaleToFitBtn.setLayoutData(new GridData(SWT.CENTER, SWT.CENTER, false, false));
 		scaleToFitBtn.setImage(UIPlugin.getDefault().getImage(UIPlugin.ICON_FA_SCALE_TO_FIT));
 		scaleToFitBtn.setSelection(false);
+		scaleToFitBtn.setToolTipText(Messages.ChartDisplayControlBar_SCALE_TO_FIT_TOOLTIP);
 		scaleToFitBtn.addListener(SWT.Selection, new Listener() {
 			@Override
 			public void handleEvent(Event event) {

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/Messages.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/Messages.java
@@ -38,6 +38,13 @@ public class Messages extends NLS {
 	private static final String BUNDLE_NAME = "org.openjdk.jmc.ui.misc.messages"; //$NON-NLS-1$
 
 	public static String AbstractWarningItem_WARNING;
+	public static String ChartDisplayControlBar_SCALE_TO_FIT_TOOLTIP;
+	public static String ChartDisplayControlBar_SELECTION_TOOL_TOOLTIP;
+	public static String ChartDisplayControlBar_ZOOM_IN_CLICK_TOOLTIP;
+	public static String ChartDisplayControlBar_ZOOM_IN_HOLD_TOOLTIP;
+	public static String ChartDisplayControlBar_ZOOM_PAN_TOOLTIP;
+	public static String ChartDisplayControlBar_ZOOM_OUT_CLICK_TOOLTIP;
+	public static String ChartDisplayControlBar_ZOOM_OUT_HOLD_TOOLTIP;
 	public static String DIALOG_FILE_EXISTS_TITLE;
 	public static String DIALOG_OVERWRITE_QUESTION_TEXT;
 	public static String EXPORT_AS_IMAGE_ACTION_TEXT;

--- a/application/org.openjdk.jmc.ui/src/main/resources/org/openjdk/jmc/ui/misc/messages.properties
+++ b/application/org.openjdk.jmc.ui/src/main/resources/org/openjdk/jmc/ui/misc/messages.properties
@@ -30,6 +30,13 @@
 #  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
 #  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
+ChartDisplayControlBar_SCALE_TO_FIT_TOOLTIP=Scale-to-Fit
+ChartDisplayControlBar_SELECTION_TOOL_TOOLTIP=Selection Tool
+ChartDisplayControlBar_ZOOM_IN_CLICK_TOOLTIP=Click: Toggle Click-to-Zoom-In mode
+ChartDisplayControlBar_ZOOM_IN_HOLD_TOOLTIP=Hold: Continuous Zoom-In
+ChartDisplayControlBar_ZOOM_PAN_TOOLTIP=Toggle Zoom-Pan Display
+ChartDisplayControlBar_ZOOM_OUT_CLICK_TOOLTIP=Click: Toggle Click-to-Zoom-Out mode
+ChartDisplayControlBar_ZOOM_OUT_HOLD_TOOLTIP=Hold: Continuous Zoom-Out
 NumberFieldEditor_ERROR_MESSAGE_INTERVAL=Must be {0} between {1} and {2}
 NumberFieldEditor_ERROR_MESSAGE_NO_GREATER=Must be {0} no greater than {2}
 NumberFieldEditor_ERROR_MESSAGE_NO_SMALLER=Must be {0} no smaller than {1}


### PR DESCRIPTION
This PR adds some tooltips to the buttons on the Display bar, and updates the thread lanes to use colours from the newly included Palette.

I manually went through the 

1. existing hex colours listed in `TypeLabelProvider` and
2. the colours returned from `ColorToolkit` when hashing the `typeId` string to generate a "unique" colour

and tried to match it with the closest possible colour in the Palette, avoiding duplicate colours. I've also re-arranged the order in `TypeLabelProvider` so they follow the order listed in the edit dialog, and introduced a couple types that were originally not included. The newer colours might look less intense in contrast, and more "dim", but right away we can see a difference in usability with these two screenshots:

Before:
![before](https://user-images.githubusercontent.com/10425301/67963289-b9c75e00-fbd4-11e9-8c30-4e8c3b63b38e.png)

After:
![after](https://user-images.githubusercontent.com/10425301/67963290-baf88b00-fbd4-11e9-9ca1-08eef22b569b.png)

The difference in the yellow colours between the `C2 CompilerThread1` and `Finalizer` is much more pronounced, and the light purple lanes in the `ForkJoinPool` threads and `Worker-0` stand out much better against the lighter gray background.
