### PR TITLE
Make zoom-to-selection work properly with display bar

### DIFF
--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/XYChart.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/XYChart.java
@@ -554,7 +554,7 @@ public class XYChart {
 		displayBar.setScaleValue(zoomSteps);
 		displayBar.setZoomPercentageText(currentZoom);
 	}
-	
+
 	/**
 	 *  When a drag-select zoom occurs, use the new range value to determine how many steps have been taken,
 	 *  and adjust zoomSteps and zoomPower accordingly
@@ -569,12 +569,28 @@ public class XYChart {
 	 * Calculate the number of steps required to achieve the passed zoom percentage
 	 */
 	private int calculateZoomSteps(double percentage) {
-		double tempPercent = 0;
-		int steps = 0;
-		do {
-			tempPercent = tempPercent + ZOOM_PAN_FACTOR;
-			steps++;
-		} while (tempPercent <= percentage);
+		int steps = (int) Math.floor(percentage / ZOOM_PAN_FACTOR);
+		double tempPercent = steps * ZOOM_PAN_FACTOR;
+
+		if (tempPercent < percentage) {
+			if (percentage > 1 - ZOOM_PAN_FACTOR) {
+				double factor = ZOOM_PAN_FACTOR;
+				do {
+					factor = factor / ZOOM_PAN_MODIFIER;
+					tempPercent = tempPercent + factor;
+					if (modifiedSteps == null) {
+						modifiedSteps = new Stack<Integer>();
+					}
+					if (modifiedSteps.size() == 0 || modifiedSteps.peek() < steps) {
+						modifiedSteps.push(steps);
+					}
+					steps++;
+				} while (tempPercent <= percentage);
+				zoomPanPower = factor / ZOOM_PAN_MODIFIER;
+			} else {
+				steps++;
+			}
+		}
 		return steps;
 	}
 

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartDisplayControlBar.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartDisplayControlBar.java
@@ -222,7 +222,7 @@ public class ChartDisplayControlBar extends Composite {
 	}
 
 	public void zoomToSelection() {
-		if (zoomInBtn.getSelection()) {
+		if (zoomInBtn.getSelection() && scale.getSelection() > 0) {
 			IQuantity selectionStart = chart.getSelectionStart();
 			IQuantity selectionEnd = chart.getSelectionEnd();
 			if (selectionStart == null || selectionEnd == null) {


### PR DESCRIPTION
This patch fixes the drag-select zoom functionality bug where the zoom slider did not adjust itself accordingly when the chart was within 5% of its max zoom view.   This was because the amount of zoomSteps that occur on a drag-select zoom action were not being calculated properly.