### PR TITLE
Lower tolerance of zoom-pan mouseDown listener for large charts

### DIFF
--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartDisplayControlBar.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartDisplayControlBar.java
@@ -352,6 +352,7 @@ public class ChartDisplayControlBar extends Composite {
 
 	private class ZoomPan extends Canvas  {
 		private static final int BORDER_PADDING = 2;
+		private static final double MIN_HEIGHT_PERCENT = 0.15;
 		private IRange<IQuantity> chartRange;
 		private IRange<IQuantity> lastChartZoomedRange;
 		private Rectangle zoomRect;
@@ -377,10 +378,19 @@ public class ChartDisplayControlBar extends Composite {
 
 			@Override
 			public void mouseDown(MouseEvent e) {
-				if (e.button == 1 && zoomRect.contains(e.x, e.y)) {
+				if (e.button == 1 && inBounds(e)) {
 					isPan = true;
 					chart.setIsZoomPanDrag(isPan);
 					currentSelection = chartCanvas.translateDisplayToImageCoordinates(e.x, e.y);
+				}
+			}
+
+			private boolean inBounds(MouseEvent e) {
+				Point zoomCanvasBounds = getParent().getSize();
+				if (zoomRect.height < MIN_HEIGHT_PERCENT * zoomCanvasBounds.y ) {
+					return zoomCanvasBounds.x >= e.x && zoomCanvasBounds.y >= e.y;
+				} else {
+					return zoomRect.contains(e.x, e.y);
 				}
 			}
 


### PR DESCRIPTION
This patch lowers the tolerance for triggering the zoom-pan mouseDown listener.  On large charts the zoom-pan indicator is very thin and hard to click.   This patch lets the listener trigger anywhere within the outer gray box, instead of only within the inner lighter grey indicator, so it doesn't matter if the cursor is off.

The other approach to solving this problem was to have a minimum height for the light grey clickable zoom-pan inner box.  However, when I tried to do this, it messed up the relative position of the chart's vertical scroll bar.  Because the width of the indicator was thicker than it should have been, when the indicator showed the chart view being at its lowest point the chart's scroll bar was not at its bottom.  Maybe there is a way to get around this issue? 
