### PR TITLE
Make textCanvas horizontal scrollbar scroll properly

### DIFF
--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/XYChart.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/XYChart.java
@@ -93,6 +93,7 @@ public class XYChart {
 	private ChartFilterControlBar filterBar;
 	private Stack<Integer> modifiedSteps;
 	private TimelineCanvas timelineCanvas;
+	private int longestCharWidth = 0;
 
 	public XYChart(IRange<IQuantity> range, IXDataRenderer rendererRoot) {
 		this(range.getStart(), range.getEnd(), rendererRoot);
@@ -321,6 +322,9 @@ public class XYChart {
 				context.drawLine(0, height - 1, axisWidth -15, height - 1);
 				int y = ((height - context.getFontMetrics().getHeight()) / 2) + context.getFontMetrics().getAscent();
 				int charsWidth = context.getFontMetrics().charsWidth(text.toCharArray(), 0, text.length());
+				if (charsWidth > longestCharWidth) {
+					longestCharWidth = charsWidth;
+				}
 				if (xOffset > 0 && charsWidth > xOffset) {
 					float fitRatio = ((float) xOffset) / (charsWidth
 							+ context.getFontMetrics().charsWidth(ELLIPSIS.toCharArray(), 0, ELLIPSIS.length()));
@@ -338,6 +342,14 @@ public class XYChart {
 			}
 		}
 		context.translate(0, height);
+	}
+
+	/**
+	 * Get the longest character width of a thread name to be rendered
+	 * @return the character width of longest thread name
+	 */
+	public int getLongestCharWidth() {
+		return longestCharWidth;
 	}
 
 	/**

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/XYChart.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/XYChart.java
@@ -143,6 +143,7 @@ public class XYChart {
 	public void setRendererRoot(IXDataRenderer rendererRoot) {
 		clearSelection();
 		this.rendererRoot = rendererRoot;
+		longestCharWidth = 0;
 	}
 
 	public IXDataRenderer getRendererRoot() {

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartTextCanvas.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartTextCanvas.java
@@ -207,7 +207,8 @@ public class ChartTextCanvas extends Canvas {
 
 		@Override
 		public void paintControl(PaintEvent e) {
-			Rectangle rect = new Rectangle(0, 0, getParent().getSize().x, getParent().getSize().y);
+			int rectWidth = Math.max(awtChart.getLongestCharWidth(), getParent().getSize().x);
+			Rectangle rect = new Rectangle(0, 0, rectWidth, getParent().getSize().y);
 			if (getNumItems() != 1 && !(MIN_LANE_HEIGHT * getNumItems() < rect.height)) {
 				rect.height = MIN_LANE_HEIGHT * getNumItems();
 			}

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartTextCanvas.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartTextCanvas.java
@@ -207,7 +207,8 @@ public class ChartTextCanvas extends Canvas {
 
 		@Override
 		public void paintControl(PaintEvent e) {
-			int rectWidth = Math.max(awtChart.getLongestCharWidth(), getParent().getSize().x);
+			int minScrollWidth = (int) ((awtChart.getLongestCharWidth() + 10) * xScale);
+			int rectWidth = Math.max(minScrollWidth, getParent().getSize().x);
 			Rectangle rect = new Rectangle(0, 0, rectWidth, getParent().getSize().y);
 			if (getNumItems() != 1 && !(MIN_LANE_HEIGHT * getNumItems() < rect.height)) {
 				rect.height = MIN_LANE_HEIGHT * getNumItems();


### PR DESCRIPTION
This patch modifies the textCanvas width that is rendered to be the maximum character width of the longest thread name.  This makes the horizontal scroll bar indicator display accurately and scroll the textCanvas width properly. 