### PR TITLE
fix timeline canvas redrawing bug and vertical sizing issue

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ChartAndPopupTableUI.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ChartAndPopupTableUI.java
@@ -46,6 +46,7 @@ import org.eclipse.swt.layout.FormLayout;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.ui.forms.widgets.FormToolkit;
@@ -70,6 +71,7 @@ import org.openjdk.jmc.ui.charts.ChartFilterControlBar;
 import org.openjdk.jmc.ui.charts.IXDataRenderer;
 import org.openjdk.jmc.ui.charts.RendererToolkit;
 import org.openjdk.jmc.ui.charts.XYChart;
+import org.openjdk.jmc.ui.common.util.Environment;
 import org.openjdk.jmc.ui.handlers.ActionToolkit;
 import org.openjdk.jmc.ui.misc.ActionUiToolkit;
 import org.openjdk.jmc.ui.misc.ChartCanvas;
@@ -80,6 +82,7 @@ import org.openjdk.jmc.ui.misc.TimelineCanvas;
 
 abstract class ChartAndPopupTableUI extends ChartAndTableUI {
 
+	private static final double Y_SCALE = Display.getCurrent().getDPI().y / Environment.getNormalDPI();
 	private static final String SASH = "sash"; //$NON-NLS-1$
 	private static final String TABLE = "table"; //$NON-NLS-1$
 	private static final String CHART = "chart"; //$NON-NLS-1$
@@ -223,9 +226,9 @@ abstract class ChartAndPopupTableUI extends ChartAndTableUI {
 		scText.setExpandHorizontal(true);
 		scText.setExpandVertical(true);
 
-		timelineCanvas = new TimelineCanvas(chartAndTimelineContainer, chartCanvas, sash);
+		timelineCanvas = new TimelineCanvas(chartAndTimelineContainer, chartCanvas, sash, Y_SCALE);
 		GridData gridData = new GridData(SWT.FILL, SWT.DEFAULT, true, false);
-		gridData.heightHint = TIMELINE_HEIGHT;
+		gridData.heightHint = (int) (TIMELINE_HEIGHT * Y_SCALE);
 		timelineCanvas.setLayoutData(gridData);
 
 		// add the display bar to the right of the chart scrolled composite

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/XYChart.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/XYChart.java
@@ -65,7 +65,6 @@ public class XYChart {
 	private IQuantity rangeDuration;
 	private IXDataRenderer rendererRoot;
 	private IRenderedRow rendererResult;
-	private boolean isRangeUpdated;
 	private final int xOffset;
 	private int yOffset = 35;
 	private final int bucketWidth;
@@ -137,7 +136,6 @@ public class XYChart {
 		this.end = end;
 		this.xOffset = xOffset;
 		this.bucketWidth = bucketWidth;
-		isRangeUpdated = false;
 	}
 	
 	public void setRendererRoot(IXDataRenderer rendererRoot) {
@@ -204,9 +202,8 @@ public class XYChart {
 		int x1 = (int) fullRangeAxis.getPixel(currentStart);
 		int x2 = (int) Math.ceil(fullRangeAxis.getPixel(currentEnd));
 		
-		if (timelineCanvas != null && isRangeUpdated) {
+		if (timelineCanvas != null) {
 			timelineCanvas.renderRangeIndicator(x1, x2);
-			isRangeUpdated = false;
 		} else {
 			context.setPaint(RANGE_INDICATION_COLOR);
 			context.fillRect(x1, rangeIndicatorY, x2 - x1, RANGE_INDICATOR_HEIGHT);
@@ -640,7 +637,6 @@ public class XYChart {
 				filterBar.setEndTime(currentEnd);
 			}
 			rangeListeners.stream().forEach(l -> l.accept(getVisibleRange()));
-			isRangeUpdated = true;
 		}
 	}
 

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/TimelineCanvas.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/TimelineCanvas.java
@@ -55,8 +55,10 @@ import org.openjdk.jmc.ui.charts.XYChart;
 import org.openjdk.jmc.ui.misc.PatternFly.Palette;
 
 public class TimelineCanvas extends Canvas {
-	private static final int RANGE_INDICATOR_HEIGHT = 10;
-	private static final int RANGE_INDICATOR_Y_OFFSET = 25;
+	private static final int BASE_RANGE_INDICATOR_HEIGHT = 10;
+	private static final int BASE_RANGE_INDICATOR_Y_OFFSET = 25;
+	private int rangeIndicatorHeight;
+	private int rangeIndicatorYOffset;
 	private int x1;
 	private int x2;
 	private int xOffset;
@@ -71,7 +73,7 @@ public class TimelineCanvas extends Canvas {
 	private SubdividedQuantityRange xTickRange;
 	private XYChart chart;
 
-	public TimelineCanvas(Composite parent, ChartCanvas chartCanvas, SashForm sashForm) {
+	public TimelineCanvas(Composite parent, ChartCanvas chartCanvas, SashForm sashForm, double yScale) {
 		super(parent, SWT.NONE);
 		this.chartCanvas = chartCanvas;
 		this.sashForm = sashForm;
@@ -80,6 +82,8 @@ public class TimelineCanvas extends Canvas {
 		DragDetector dragDetector = new DragDetector();
 		addMouseListener(dragDetector);
 		addMouseMoveListener(dragDetector);
+		rangeIndicatorHeight = (int) (BASE_RANGE_INDICATOR_HEIGHT * yScale);
+		rangeIndicatorYOffset = (int) (BASE_RANGE_INDICATOR_Y_OFFSET * yScale);
 	}
 
 	private int calculateXOffset() {
@@ -123,8 +127,8 @@ public class TimelineCanvas extends Canvas {
 
 			// Draw the range indicator
 			indicatorRect = dragRect != null ? dragRect : new Rectangle(
-					x1 + xOffset, chartCanvas.translateDisplayToImageYCoordinates(RANGE_INDICATOR_Y_OFFSET),
-					x2 - x1, chartCanvas.translateDisplayToImageYCoordinates(RANGE_INDICATOR_HEIGHT));
+					x1 + xOffset, chartCanvas.translateDisplayToImageYCoordinates(rangeIndicatorYOffset),
+					x2 - x1, chartCanvas.translateDisplayToImageYCoordinates(rangeIndicatorHeight));
 			dragRect = null;
 			g2d.setPaint(Palette.PF_ORANGE_400.getAWTColor());
 			g2d.fillRect(indicatorRect.x, indicatorRect.y, indicatorRect.width, indicatorRect.height);
@@ -132,8 +136,8 @@ public class TimelineCanvas extends Canvas {
 			Point totalSize = sashForm.getChildren()[1].getSize();
 			adjusted = chartCanvas.translateDisplayToImageCoordinates(totalSize.x, totalSize.y);
 			timelineRect = new Rectangle(
-					xOffset, chartCanvas.translateDisplayToImageYCoordinates(RANGE_INDICATOR_Y_OFFSET),
-					adjusted.x, chartCanvas.translateDisplayToImageYCoordinates(RANGE_INDICATOR_HEIGHT));
+					xOffset, chartCanvas.translateDisplayToImageYCoordinates(rangeIndicatorYOffset),
+					adjusted.x, chartCanvas.translateDisplayToImageYCoordinates(rangeIndicatorHeight));
 			g2d.setPaint(Palette.PF_BLACK_600.getAWTColor());
 			g2d.drawRect(timelineRect.x, timelineRect.y, timelineRect.width, timelineRect.height);
 


### PR DESCRIPTION
This PR addresses two issues:
- a regression added in 6ab1599 that caused the timeline canvas to not redraw itself when the sashform/window are resized
- if the DPI is larger than expected, then the timeline canvas elements do not adjust and the range indicator overlaps the axis text

Before:
![before](https://user-images.githubusercontent.com/10425301/69067203-af88ca80-09f0-11ea-8284-66acfd319a75.png)

After:
![after](https://user-images.githubusercontent.com/10425301/69067204-b0b9f780-09f0-11ea-9e27-0e2b1d9f1821.png)
