### PR TITLE
fix painting of toolbars in Windows

### DIFF
--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/ChartFilterControlBar.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/ChartFilterControlBar.java
@@ -54,11 +54,12 @@ public class ChartFilterControlBar extends Composite {
 	private TimeFilter timeFilter;
 
 	public ChartFilterControlBar(Composite parent, Listener resetListener, IRange<IQuantity> recordingRange) {
-		super(parent, SWT.NO_BACKGROUND);
+		super(parent, SWT.NONE);
 		this.setLayout(new GridLayout(3, false));
 		this.setBackground(Palette.PF_BLACK_300.getSWTColor());
 		Label nameLabel = new Label(this, SWT.CENTER | SWT.HORIZONTAL);
 		nameLabel.setText(THREADS_LABEL);
+		nameLabel.setBackground(Palette.PF_BLACK_300.getSWTColor());
 		GridData gd = new GridData(SWT.FILL, SWT.CENTER, false, true);
 		gd.widthHint = 180;
 		nameLabel.setLayoutData(gd);

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartDisplayControlBar.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartDisplayControlBar.java
@@ -89,7 +89,7 @@ public class ChartDisplayControlBar extends Composite {
 	private ZoomPan zoomPan;
 
 	public ChartDisplayControlBar(Composite parent) {
-		super(parent, SWT.NO_BACKGROUND);
+		super(parent, SWT.NONE);
 
 		this.setLayout(new GridLayout());
 		this.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, true));

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/TimeFilter.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/TimeFilter.java
@@ -63,14 +63,17 @@ public class TimeFilter extends Composite {
 		Label eventsLabel = new Label(this, SWT.LEFT);
 		eventsLabel.setText(Messages.TimeFilter_FILTER_EVENTS);
 		eventsLabel.setFont(JFaceResources.getFontRegistry().get(JFaceResources.BANNER_FONT));
+		eventsLabel.setBackground(Palette.PF_BLACK_300.getSWTColor());
 
-		Label from = new Label(this, SWT.CENTER);
-		from.setText(Messages.TimeFilter_FROM);
+		Label fromLabel = new Label(this, SWT.CENTER);
+		fromLabel.setText(Messages.TimeFilter_FROM);
+		fromLabel.setBackground(Palette.PF_BLACK_300.getSWTColor());
 
 		startDisplay = new TimeDisplay(this);
 
-		Label to = new Label(this, SWT.CENTER);
-		to.setText(Messages.TimeFilter_TO);
+		Label toLabel = new Label(this, SWT.CENTER);
+		toLabel.setText(Messages.TimeFilter_TO);
+		toLabel.setBackground(Palette.PF_BLACK_300.getSWTColor());
 
 		endDisplay = new TimeDisplay(this);
 


### PR DESCRIPTION
This short PR addresses an issue in Windows where the the toolbars weren't being coloured correctly. The issue was that `SWT.NO_BACKGROUND` in Windows creates an almost transparent-like effect; preserving the visual of the previously painted component in that space. For example, when loading the Threads page the background of the toolbars would display whatever was on the page previous to the Threads page (e.g., Automatic Analysis page) and it really threw off the aesthetic of the page. The fix here is to use `SWT.NONE` in the constructor, and because the page is wrapped in a ScrolledComposite (and doesn't correctly let child components inherit backgrounds) the background needed to be set in a couple more places - primarily in labels.