### PR TITLE
Make chart and text canvas right-click menus the same

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/DropdownLaneFilter.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/DropdownLaneFilter.java
@@ -58,16 +58,16 @@ public class DropdownLaneFilter extends Composite {
 	private static final int SHELL_HEIGHT = 400;
 	private Button dropdownButton;
 	private GridLayout layout;
-	private MCContextMenuManager mm;
+	private MCContextMenuManager[] mms;
 	private Shell shell;
 	private ShellAdapter shellDisposeAdapter;
 	private ThreadGraphLanes lanes;
 	private TypeFilterBuilder filterEditor;
 
-	public DropdownLaneFilter(Composite parent, ThreadGraphLanes lanes, MCContextMenuManager mm) {
+	public DropdownLaneFilter(Composite parent, ThreadGraphLanes lanes, MCContextMenuManager[] mms) {
 		super(parent, SWT.NONE);
 		this.lanes = lanes;
-		this.mm = mm;
+		this.mms = mms;
 		this.setBackground(Palette.PF_BLACK_300.getSWTColor());
 		this.layout = createGridLayout();
 		this.shellDisposeAdapter = new ShellAdapter() {
@@ -140,6 +140,6 @@ public class DropdownLaneFilter extends Composite {
 		LaneDefinition quickLaneDef = new LaneDefinition(Messages.DropdownLaneFilter_QUICK_FILTER, true,
 					ItemFilters.type(filterEditor.getCheckedTypeIds().collect(Collectors.toSet())), false);
 		lanes.useDropdownFilter(quickLaneDef);
-		lanes.updateContextMenu(mm, false);
+		lanes.updateContextMenus(mms, false);
 	}
 }

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ChartAndPopupTableUI.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ChartAndPopupTableUI.java
@@ -285,6 +285,9 @@ abstract class ChartAndPopupTableUI extends ChartAndTableUI {
 		SelectionStoreActionToolkit.addSelectionStoreRangeActions(pageContainer.getSelectionStore(), chart,
 				JfrAttributes.LIFETIME, NLS.bind(Messages.ChartAndTableUI_TIMELINE_SELECTION, form.getText()),
 				chartCanvas.getContextMenu());
+		SelectionStoreActionToolkit.addSelectionStoreRangeActions(pageContainer.getSelectionStore(), chart,
+				JfrAttributes.LIFETIME, NLS.bind(Messages.ChartAndTableUI_TIMELINE_SELECTION, form.getText()),
+				textCanvas.getContextMenu());
 
 		// Wire-up the chart & text canvases to the filter and display bars
 		displayBar.setChart(chart);

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ChartAndPopupTableUI.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ChartAndPopupTableUI.java
@@ -88,7 +88,6 @@ abstract class ChartAndPopupTableUI extends ChartAndTableUI {
 	private static final String TABLE = "table"; //$NON-NLS-1$
 	private static final String CHART = "chart"; //$NON-NLS-1$
 	private static final String SELECTED = "selected"; //$NON-NLS-1$
-	private static final String NO_INPUT_METHOD = "org.eclipse.swt.internal.gtk.noInputMethod"; //$NON-NLS-1$
 	private static final int TIMELINE_HEIGHT = 40;
 	private static final int X_OFFSET = 0;
 	private static final int Y_OFFSET = 0;
@@ -116,7 +115,6 @@ abstract class ChartAndPopupTableUI extends ChartAndTableUI {
 		this.pageFilter = pageFilter;
 		this.model = model;
 		this.pageContainer = pageContainer;
-		Display.getCurrent().setData(NO_INPUT_METHOD, true);
 		form = DataPageToolkit.createForm(parent, toolkit, sectionTitle, icon);
 
 		hiddenTableContainer = new Composite(form, SWT.NONE);

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ChartAndPopupTableUI.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ChartAndPopupTableUI.java
@@ -88,6 +88,7 @@ abstract class ChartAndPopupTableUI extends ChartAndTableUI {
 	private static final String TABLE = "table"; //$NON-NLS-1$
 	private static final String CHART = "chart"; //$NON-NLS-1$
 	private static final String SELECTED = "selected"; //$NON-NLS-1$
+	private static final String NO_INPUT_METHOD = "org.eclipse.swt.internal.gtk.noInputMethod"; //$NON-NLS-1$
 	private static final int TIMELINE_HEIGHT = 40;
 	private static final int X_OFFSET = 0;
 	private static final int Y_OFFSET = 0;
@@ -115,6 +116,7 @@ abstract class ChartAndPopupTableUI extends ChartAndTableUI {
 		this.pageFilter = pageFilter;
 		this.model = model;
 		this.pageContainer = pageContainer;
+		Display.getCurrent().setData(NO_INPUT_METHOD, true);
 		form = DataPageToolkit.createForm(parent, toolkit, sectionTitle, icon);
 
 		hiddenTableContainer = new Composite(form, SWT.NONE);

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ThreadsPage.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ThreadsPage.java
@@ -52,6 +52,7 @@ import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Item;
 import org.eclipse.ui.forms.widgets.FormToolkit;
 import org.openjdk.jmc.common.IMCThread;
@@ -369,6 +370,7 @@ public class ThreadsPage extends AbstractDataPage {
 		public void saveTo(IWritableState state) {
 			super.saveTo(state);
 			saveToLocal();
+			Display.getCurrent().setData(NO_INPUT_METHOD, null);
 		}
 
 		private void saveToLocal() {
@@ -454,6 +456,7 @@ public class ThreadsPage extends AbstractDataPage {
 		}
 	}
 
+	private static final String NO_INPUT_METHOD = "org.eclipse.swt.internal.gtk.noInputMethod"; //$NON-NLS-1$
 	private Object[] selectionInput;
 	private FlavorSelectorState flavorSelectorState;
 	private SelectionState histogramSelectionState;
@@ -463,6 +466,7 @@ public class ThreadsPage extends AbstractDataPage {
 	public ThreadsPage(IPageDefinition definition, StreamModel model, IPageContainer editor) {
 		super(definition, model, editor);
 		visibleRange = editor.getRecordingRange();
+		Display.getCurrent().setData(NO_INPUT_METHOD, true);
 	}
 
 	@Override

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartTextCanvas.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartTextCanvas.java
@@ -71,6 +71,8 @@ public class ChartTextCanvas extends Canvas {
 	private int laneHeight = DEFAULT_LANE_HEIGHT;
 	private int minLaneheight = 20;
 	private int numItems;
+	private int lastMouseX = -1;
+	private int lastMouseY = -1;
 	private List<Rectangle2D> highlightRects;
 
 	private class Selector extends MouseAdapter implements MouseMoveListener, MouseTrackListener {
@@ -154,6 +156,8 @@ public class ChartTextCanvas extends Canvas {
 				highlightRects = null;
 				updateSelectionState(e);
 			} else {
+				lastMouseX = e.x;
+				lastMouseY = e.y;
 				updateHighlightRects();
 			}
 		}
@@ -189,6 +193,9 @@ public class ChartTextCanvas extends Canvas {
 
 		@Override
 		public void mouseExit(MouseEvent e) {
+			if (!getClientArea().contains(e.x, e.y)) {
+				resetHoveredItemData();
+			}
 			clearHighlightRects();
 		}
 
@@ -294,6 +301,7 @@ public class ChartTextCanvas extends Canvas {
 	private XYChart awtChart;
 	private ChartCanvas chartCanvas;
 	private MCContextMenuManager chartMenu;
+	private Object hoveredItemData;
 
 	public ChartTextCanvas(Composite parent) {
 		super(parent, SWT.NO_BACKGROUND);
@@ -330,6 +338,17 @@ public class ChartTextCanvas extends Canvas {
 			awtChart.renderTextCanvasText(context, width);
 		}
 	}
+	public Object getHoveredItemData() {
+		return this.hoveredItemData;
+	}
+
+	public void setHoveredItemData(Object data) {
+		this.hoveredItemData = data;
+	}
+
+	public void resetHoveredItemData() {
+		this.hoveredItemData = null;
+	}
 
 	public void syncHighlightedRectangles (List<Rectangle2D> newRects) {
 		highlightRects = newRects;
@@ -337,6 +356,14 @@ public class ChartTextCanvas extends Canvas {
 	}
 
 	private void updateHighlightRects() {
+		infoAt(new IChartInfoVisitor.Adapter() {
+			@Override
+			public void hover(Object data) {
+				if (data != null) {
+					setHoveredItemData(data);
+				}
+			}
+		}, lastMouseX, lastMouseY);
 		redraw();
 		if (chartCanvas != null) {
 			chartCanvas.syncHighlightedRectangles(highlightRects);


### PR DESCRIPTION
This patch makes the text and chart canvases' right click menus the same.