### PR TITLE
Fix windows rendering issues

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ChartAndPopupTableUI.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ChartAndPopupTableUI.java
@@ -252,16 +252,16 @@ abstract class ChartAndPopupTableUI extends ChartAndTableUI {
 		scText.setExpandHorizontal(true);
 		scText.setExpandVertical(true);
 
-		Composite timlineAndHeightBtnsContainer = toolkit.createComposite(chartAndTimelineContainer);
+		Composite timelineAndHeightBtnsContainer = toolkit.createComposite(chartAndTimelineContainer);
 		gridLayout = new GridLayout(2, false);
 		gridLayout.horizontalSpacing = 0;
-		timlineAndHeightBtnsContainer.setLayout(gridLayout);
-		timlineAndHeightBtnsContainer.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
+		timelineAndHeightBtnsContainer.setLayout(gridLayout);
+		timelineAndHeightBtnsContainer.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
 
-		heightBtns = new ChartLaneHeightControls(timlineAndHeightBtnsContainer, chartCanvas, textCanvas);
+		heightBtns = new ChartLaneHeightControls(timelineAndHeightBtnsContainer, chartCanvas, textCanvas);
 		heightBtns.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, false));
 
-		timelineCanvas = new TimelineCanvas(timlineAndHeightBtnsContainer, chartCanvas, sash, Y_SCALE);
+		timelineCanvas = new TimelineCanvas(timelineAndHeightBtnsContainer, chartCanvas, sash, Y_SCALE);
 		GridData gridData = new GridData(SWT.FILL, SWT.DEFAULT, true, false);
 		gridData.heightHint = (int) (TIMELINE_HEIGHT * Y_SCALE);
 		timelineCanvas.setLayoutData(gridData);

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/XYChart.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/XYChart.java
@@ -205,11 +205,18 @@ public class XYChart {
 		
 		if (timelineCanvas != null) {
 			timelineCanvas.renderRangeIndicator(x1, x2);
+			updateZoomPanIndicator();
 		} else {
 			context.setPaint(RANGE_INDICATION_COLOR);
 			context.fillRect(x1, rangeIndicatorY, x2 - x1, RANGE_INDICATOR_HEIGHT);
 			context.setPaint(Color.DARK_GRAY);
 			context.drawRect(0, rangeIndicatorY, axisWidth - 1, RANGE_INDICATOR_HEIGHT);
+		}
+	}
+
+	public void updateZoomPanIndicator() {
+		if (displayBar != null) {
+			displayBar.updateZoomPanIndicator();
 		}
 	}
 

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/XYChart.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/XYChart.java
@@ -180,10 +180,10 @@ public class XYChart {
 		}
 	}
 
-	public void renderTextCanvasText(Graphics2D context, int width) {
+	public void renderTextCanvasText(Graphics2D context, int width, int height) {
 		axisWidth = width;
 		AffineTransform oldTransform = context.getTransform();
-		doRenderTextCanvasText(context);
+		doRenderTextCanvasText(context, height);
 		context.setTransform(oldTransform);
 	}
 
@@ -220,6 +220,17 @@ public class XYChart {
 		}
 	}
 
+	private IRenderedRow getRendererResult(Graphics2D context, int axisHeight) {
+		if (xBucketRange == null) {
+			xBucketRange = getXBucketRange();
+		}
+		return rendererRoot.render(context, xBucketRange, axisHeight);
+	}
+
+	private SubdividedQuantityRange getXBucketRange() {
+		return new SubdividedQuantityRange(currentStart, currentEnd, axisWidth, bucketWidth);
+	}
+
 	private void doRenderChart(Graphics2D context, int axisHeight) {
 		rowColorCounter = 0;
 		context.setPaint(Color.LIGHT_GRAY);
@@ -232,7 +243,7 @@ public class XYChart {
 			AWTChartToolkit.drawAxis(context, xTickRange, axisHeight - 1, false, 1 - xOffset, false);
 		}
 		// ... then the graph ...
-		rendererResult = rendererRoot.render(context, xBucketRange, axisHeight);
+		rendererResult = getRendererResult(context, axisHeight);
 		AffineTransform oldTransform = context.getTransform();
 
 		context.setTransform(oldTransform);
@@ -253,7 +264,10 @@ public class XYChart {
 		context.setTransform(oldTransform);
 	}
 
-	private void doRenderTextCanvasText(Graphics2D context) {
+	private void doRenderTextCanvasText(Graphics2D context, int height) {
+		if (rendererResult == null) {
+			rendererResult = getRendererResult(context, height - yOffset);
+		}
 		AffineTransform oldTransform = context.getTransform();
 		rowColorCounter = 0;
 		renderText(context, rendererResult);

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartCanvas.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartCanvas.java
@@ -456,6 +456,7 @@ public class ChartCanvas extends Canvas {
 		if (textCanvas != null) {
 			Point location = ((ScrolledComposite) getParent()).getOrigin();
 			textCanvas.syncScroll(location);
+			awtChart.updateZoomPanIndicator();
 		}
 	}
 
@@ -473,6 +474,7 @@ public class ChartCanvas extends Canvas {
 			if (textCanvas == null) {
 				awtChart.renderText(context, width, height);
 			}
+			awtChart.updateZoomPanIndicator();
 		}
 	}
 

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartDisplayControlBar.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartDisplayControlBar.java
@@ -226,6 +226,10 @@ public class ChartDisplayControlBar extends Composite {
 		this.textCanvas = textCanvas;
 	}
 
+	public void updateZoomPanIndicator() {
+		zoomPan.redraw();
+	}
+
 	public void zoomOnClick(Boolean mouseDown) {
 		boolean shouldZoom = zoomInBtn.getSelection() || zoomOutBtn.getSelection() ;
 		if (shouldZoom) {

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartTextCanvas.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartTextCanvas.java
@@ -335,7 +335,7 @@ public class ChartTextCanvas extends Canvas {
 
 	private void render(Graphics2D context, int width, int height) {
 		if (awtChart != null) {
-			awtChart.renderTextCanvasText(context, width);
+			awtChart.renderTextCanvasText(context, width, height);
 		}
 	}
 	public Object getHoveredItemData() {


### PR DESCRIPTION
This PR addresses two issues that the Threads Page was encountering in Windows.

1). The zoom-pan indicator was not responding to updates of the chart

When the chart was updated (zoom, pan, change lane height, etc.) or if the zoom-pan indicator was dragged, in Windows the indicator would not update to show the current view of the chart. It turns out that Windows doesn't redraw as frequently as Linux, and redraws need to be enforced. The fix was to add a redraw function for the zoom-pan indicator, that can be called whenever the chart is re-rendered.

2). The Text Canvas was throwing a NPE when drawing the text initially

The text (and chart lanes) is dependent on the `rendererResult` in `XYChart` being generated. This is currently done in the rendering functions stemming from the chart canvas. However, the ordering of the widgets in the SWT widget table differs in Windows and Linux, so there is no guarantee that the chart canvas will be rendered first, causing a NPE in Windows because the text canvas takes a later index in the widget table. To fix, allow the text canvas to generated the `rendererResult` and `xBucket` if it is `null`, which would only occur on the first render of the page and only given the specific condition that the text canvas would be drawn before the chart canvas.

For a bit of background, the SWT widget tables for Windows vs. Linux had the same order for additions into the widget table, but the order of storage and drawing was different. Windows seems to take a more linear approach, where widgets are placed into a large array as they are seen, whereas Linux spaces them out more across the indices of the list resembling a hash map. For example, in Windows the order around the canvases looked something like .. `[..., ScrolledComposite, TextCanvas, ScrolledComposite, ChartCanvas, ...]`, but in Linux they were mapped to locations up to 100 indices apart, with the `ChartCanvas` being placed in a lower index than the `TextCanvas`.