### PR TITLE
adjust the component background colour and margin  for the timeline container

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ChartAndPopupTableUI.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ChartAndPopupTableUI.java
@@ -255,6 +255,7 @@ abstract class ChartAndPopupTableUI extends ChartAndTableUI {
 		Composite timelineAndHeightBtnsContainer = toolkit.createComposite(chartAndTimelineContainer);
 		gridLayout = new GridLayout(2, false);
 		gridLayout.horizontalSpacing = 0;
+		gridLayout.marginWidth = 0;
 		timelineAndHeightBtnsContainer.setLayout(gridLayout);
 		timelineAndHeightBtnsContainer.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
 

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/ChartFilterControlBar.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/ChartFilterControlBar.java
@@ -56,10 +56,10 @@ public class ChartFilterControlBar extends Composite {
 	public ChartFilterControlBar(Composite parent, Listener resetListener, IRange<IQuantity> recordingRange) {
 		super(parent, SWT.NONE);
 		this.setLayout(new GridLayout(3, false));
-		this.setBackground(Palette.PF_BLACK_300.getSWTColor());
+		this.setBackground(Palette.getThreadsPageBackgroundColor());
 		Label nameLabel = new Label(this, SWT.CENTER | SWT.HORIZONTAL);
 		nameLabel.setText(THREADS_LABEL);
-		nameLabel.setBackground(Palette.PF_BLACK_300.getSWTColor());
+		nameLabel.setBackground(Palette.getThreadsPageBackgroundColor());
 		GridData gd = new GridData(SWT.FILL, SWT.CENTER, false, true);
 		gd.widthHint = 180;
 		nameLabel.setLayoutData(gd);

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartDisplayControlBar.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartDisplayControlBar.java
@@ -94,7 +94,7 @@ public class ChartDisplayControlBar extends Composite {
 
 		this.setLayout(new GridLayout());
 		this.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, true));
-		this.setBackground(Palette.PF_BLACK_300.getSWTColor());
+		this.setBackground(Palette.getThreadsPageBackgroundColor());
 
 		cursors = new HashMap<>();
 		cursors.put(DEFAULT_CURSOR, getDisplay().getSystemCursor(SWT.CURSOR_ARROW));

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/PatternFly.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/PatternFly.java
@@ -33,6 +33,7 @@
  */
 package org.openjdk.jmc.ui.misc;
 
+import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.widgets.Display;
 
 public class PatternFly {
@@ -190,6 +191,13 @@ public class PatternFly {
 		 */
 		public org.eclipse.swt.graphics.Color getSWTColor() {
 			return (org.eclipse.swt.graphics.Color) parseRGB(SWT);
+		}
+
+		/**
+		 * Page & Component Specific Colors
+		 */
+		public static Color getThreadsPageBackgroundColor() {
+			return PF_BLACK_200.getSWTColor();
 		}
 	}
 }

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/TimeFilter.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/TimeFilter.java
@@ -68,22 +68,22 @@ public class TimeFilter extends Composite {
 	public TimeFilter(Composite parent, IRange<IQuantity> recordingRange, Listener resetListener) {
 		super(parent, SWT.NONE);
 		this.recordingRange = recordingRange;
-		this.setBackground(Palette.PF_BLACK_300.getSWTColor());
+		this.setBackground(Palette.getThreadsPageBackgroundColor());
 		this.setLayout(new GridLayout(7, false));
 		Label eventsLabel = new Label(this, SWT.LEFT);
 		eventsLabel.setText(Messages.TimeFilter_FILTER_EVENTS);
 		eventsLabel.setFont(JFaceResources.getFontRegistry().get(JFaceResources.BANNER_FONT));
-		eventsLabel.setBackground(Palette.PF_BLACK_300.getSWTColor());
+		eventsLabel.setBackground(Palette.getThreadsPageBackgroundColor());
 
 		Label fromLabel = new Label(this, SWT.CENTER);
 		fromLabel.setText(Messages.TimeFilter_FROM);
-		fromLabel.setBackground(Palette.PF_BLACK_300.getSWTColor());
+		fromLabel.setBackground(Palette.getThreadsPageBackgroundColor());
 
 		startDisplay = new TimeDisplay(this);
 
 		Label toLabel = new Label(this, SWT.CENTER);
 		toLabel.setText(Messages.TimeFilter_TO);
-		toLabel.setBackground(Palette.PF_BLACK_300.getSWTColor());
+		toLabel.setBackground(Palette.getThreadsPageBackgroundColor());
 
 		endDisplay = new TimeDisplay(this);
 
@@ -153,7 +153,7 @@ public class TimeFilter extends Composite {
 
 		public TimeDisplay(TimeFilter parent) {
 			super(parent, SWT.NONE);
-			this.setBackground(Palette.PF_BLACK_300.getSWTColor());
+			this.setBackground(Palette.getThreadsPageBackgroundColor());
 			this.setLayout(new GridLayout());
 			timeText = new Text(this, SWT.SEARCH | SWT.SINGLE);
 			timeText.setTextLimit(12);


### PR DESCRIPTION
This small PR adjusts two minor visual nits:

1. The shade of `PF_BLACK` used previously may have been a bit too dark, so a lighter one was chosen to give a closer look to the rest of the JMC pages.

2. With the addition of the composite to hold the timeline and lane height controls, the horizontal margin needs to be made 0 to ensure the entire timeline canvas is displayed (it's off the right side by a couple of pixels).

Timeline before:
![before](https://user-images.githubusercontent.com/10425301/71189017-1ac3f780-2250-11ea-8bc6-ab7ab389e039.png)

Timeline after:
![after](https://user-images.githubusercontent.com/10425301/71189016-1ac3f780-2250-11ea-98f7-3f2c6144163b.png)

Overview w/new colour and timeline margin:
![2019-12-17-133050_1040x632_scrot](https://user-images.githubusercontent.com/10425301/71189009-14358000-2250-11ea-90ae-9f0003a9ef01.png)
